### PR TITLE
Stylize 'Snap' as 'Snap!' with italics across the project, fixing CSS and LaTeX rendering

### DIFF
--- a/00-acknowledgements.md
+++ b/00-acknowledgements.md
@@ -10,11 +10,11 @@ programming in the great days of {index}`Xerox PARC`. He
 worked with {index}`John Maloney<single: Maloney, John>`, of the MIT
 \index{Massachusetts Institute of Technology} Scratch Team
 \index{Scratch!Team@Scratch Team}, who developed the Morphic\index{Morphic}
-graphics framework that’s still at the heart of {.snap}`Snap`.
+graphics framework that’s still at the heart of [Snap!]{.snap}.
 
 <strong><em>The brilliant design of Scratch, from the Lifelong Kindergarten
 Group\index{Lifelong Kindergarten Group} at the MIT Media Lab
-\index{Media Lab}\index{MIT Media Lab}, is crucial to {.snap}`Snap`. Our earlier version, BYOB, was a direct modification of the Scratch source code. {.snap}`Snap` is a complete rewrite, but its code structure and its user interface remain deeply indebted to Scratch. And the Scratch Team, who could have seen us as rivals, have been entirely supportive and welcoming to us.</em></strong>
+\index{Media Lab}\index{MIT Media Lab}, is crucial to [Snap!]{.snap}. Our earlier version, BYOB, was a direct modification of the Scratch source code. [Snap!]{.snap} is a complete rewrite, but its code structure and its user interface remain deeply indebted to Scratch. And the Scratch Team, who could have seen us as rivals, have been entirely supportive and welcoming to us.</em></strong>
 
 Brian grew up at the MIT and Stanford Artificial Intelligence Labs
 \index{MIT Artificial Intelligence Lab}\index{Stanford Artificial Intelligence Lab}, learning from Lisp inventor
@@ -30,11 +30,11 @@ Iverson\index{Iverson, Kenneth E.}, the inventor of APL\index{APL}.)
 
 ***In the glory days of the MIT Logo Lab, we used to say, “Logo is Lisp
 disguised as BASIC.” Now, with its first class procedures, lexical
-scope, and first class continuations,* Snap*! is Scheme disguised as
+scope, and first class continuations, [Snap!]{.snap} is Scheme disguised as
 Scratch.***
 
 Four people have made such massive contributions to the implementation
-of {.snap}`Snap` that we have officially declared them members of the team:
+of [Snap!]{.snap} that we have officially declared them members of the team:
 {index}`Michael Ball<single: Ball, Michael>` and Bernat Romagosa, in addition to
 contributions throughout the project, have primary responsibility for
 the web site and {index}`cloud storage<single: storage, cloud>`. Joan Guillén i
@@ -42,14 +42,14 @@ Pelegay\index{Guillén i Pelegay, Joan} has contributed very careful and
 wise analysis of outstanding issues, including help in taming the
 management of translations to non-English languages. Jadga Hügle
 \index{Huegle, Jadga}, has energetically contributed to online
-mini-courses about {.snap}`Snap` and leading workshops for kids and for
-adults. Jens, Jadga, and Bernat are paid to work on {.snap}`Snap` by SAP,
+mini-courses about [Snap!]{.snap} and leading workshops for kids and for
+adults. Jens, Jadga, and Bernat are paid to work on [Snap!]{.snap} by SAP,
 which also supports our computing needs.
 
 We have been fortunate to get to know an amazing group of brilliant
 middle school(!) and high school students through the Scratch Advanced
 Topics forum, several of whom (since grown up) have contributed code to
-{.snap}`Snap`: {index}`Kartik Chandra<single: Chandra, Kartik>`, Nathan Dinsmore
+[Snap!]{.snap}: {index}`Kartik Chandra<single: Chandra, Kartik>`, Nathan Dinsmore
 \index{Dinsmore, Nathan}, {index}`Connor Hudson<single: Hudson, Connor>`, Ian
 Reynolds\index{Reynolds, Ian}, and Deborah Servilla\index{Servilla,
 Deborah} . Many more have contributed ideas and alpha-testing bug
@@ -57,7 +57,7 @@ reports. UC Berkeley students who’ve contributed code include Achal Dave
 \index{Dave, Achal}. Kyle Hotchkiss\index{Hotchkiss. Kyle}, Ivan
 Motyashov\index{Motyashov, Ivan}, and {index}`Yuan Yuan<single: Yuan, Yuan>`.
 Contributors of translations are too numerous to list here, but they’re
-in the “About…” box in {.snap}`Snap` itself.
+in the “About…” box in [Snap!]{.snap} itself.
 
 This material is based upon work supported in part by the National
 Science Foundation under Grants No.

--- a/01-blocks-scripts-and-sprites.md
+++ b/01-blocks-scripts-and-sprites.md
@@ -5,15 +5,15 @@ toc: true
 (sec-ch01)=
 # 1. Blocks, Scripts, and Sprites
 
-This chapter describes the {.snap}`Snap` features inherited from {index}`Scratch`; experienced Scratch users can skip to @sec-sprites-parallelism.
+This chapter describes the [Snap!]{.snap} features inherited from {index}`Scratch`; experienced Scratch users can skip to @sec-sprites-parallelism.
 
-{.snap}`Snap` is a programming language—a notation in which you can tell a
+[Snap!]{.snap} is a programming language—a notation in which you can tell a
 computer what you want it to do. Unlike most programming languages,
-though, {.snap}`Snap` is a *visual* language; instead of writing a program
-using the keyboard, the {.snap}`Snap` programmer uses the same drag-and-drop
+though, [Snap!]{.snap} is a *visual* language; instead of writing a program
+using the keyboard, the [Snap!]{.snap} programmer uses the same drag-and-drop
 interface familiar to computer users.
 
-Start {.snap}`Snap`. You should see the following
+Start [Snap!]{.snap}. You should see the following
 arrangement of regions\index{layout, window} in the window:
 
 ![An annotated screenshot of blank Snap! editor](./12-user-interface-elements/assets/snap-ide-annotated.png)
@@ -21,7 +21,7 @@ arrangement of regions\index{layout, window} in the window:
 (The proportions of these areas may be different, depending on the size
 and shape of your browser window.)
 
-A {.snap}`Snap` program\index{"Snap! program"} consists of one or more
+A [Snap!]{.snap} program\index{"Snap! program"} consists of one or more
 *scripts,* each of which is made of *blocks.* Here’s a typical script
 \index{script} :
 
@@ -36,7 +36,7 @@ Control palette; the green block is from the Pen palette; and the blue
 blocks are from the Motion palette. A script is assembled by dragging
 blocks from a palette into the *scripting area*\index{scripting area}
 in the middle part of the window. Blocks snap together (hence the name
-{.snap}`Snap` for the language) when you drag a block so that its indentation
+[Snap!]{.snap} for the language) when you drag a block so that its indentation
 is near the tab of the one above it:
 
 ```{subfigure} snapping-blocks
@@ -57,8 +57,8 @@ At the top of the script is a *hat* block, which indicates when the
 script should be carried out. Hat block names typically start with the
 word “when”; in the square-drawing example in @fig-draw-square, the script should
 be run when the {index}`green flag<single: flag, green>` near the right end of the
-{.snap}`Snap` {index}`tool bar` is clicked. (The {.snap}`Snap` tool bar is
-part of the {.snap}`Snap` window, not the same as the browser’s or operating
+[Snap!]{.snap} {index}`tool bar` is clicked. (The [Snap!]{.snap} tool bar is
+part of the [Snap!]{.snap} window, not the same as the browser’s or operating
 system’s menu bar.) A script isn’t required to have a hat block
 \index{block!hat}, but if not, then the script will be run only if the
 user clicks on the script itself. A script can’t have more than one hat
@@ -79,7 +79,7 @@ instead of octagonal. {#para-generic-when}
 
 The other blocks in our example script are *command* blocks
 \index{block!command}. Each {index}`command block`
-corresponds to an action that {.snap}`Snap` already knows how to carry out.
+corresponds to an action that [Snap!]{.snap} already knows how to carry out.
 For example, the block ![image9.png](./blocks/images/block_forward.png){.image-inline} tells the sprite\index{sprite} (the arrowhead
 shape on the *stage*\index{stage} at the right end of the window) to
 move ten steps (a step is a very small unit of distance) in the
@@ -210,7 +210,7 @@ costume stored on your own computer, is to click on the file icon and
 choose the “Import…” menu item. You can then select a file in any
 picture format (PNG, JPEG, etc.) supported by your browser. The third
 way is quicker if the file you want is visible on the desktop: Just drag
-the file onto the {.snap}`Snap` window. In any of these cases, the scripting
+the file onto the [Snap!]{.snap} window. In any of these cases, the scripting
 area will be replaced by something like this:
 
 ![image31.png](images/01-blocks-scripts-and-sprites/image31.png)
@@ -220,9 +220,9 @@ Costumes, and Sounds. You’ll see that the Costumes tab\index{Costumes
 tab} is now selected. In this view, the sprite’s *wardrobe,*
 \index{wardrobe} you can choose whether the sprite should wear its
 Turtle costume or its Alonzo\index{Alonzo} costume. (Alonzo, the
-{.snap}`Snap` mascot, is named after {index}`Alonzo Church<single: Church, Alonzo>`, a
+[Snap!]{.snap} mascot, is named after {index}`Alonzo Church<single: Church, Alonzo>`, a
 mathematician who invented the idea of procedures as data
-\index{procedures as data}, the most important way in which {.snap}`Snap` is
+\index{procedures as data}, the most important way in which [Snap!]{.snap} is
 different from Scratch\index{Scratch}.) You can give a sprite as many
 costumes as you like, and then choose which it will wear either by
 clicking in its wardrobe or by using the ![image35.png](./blocks/images/block_doSwitchToCostume.png){.image-inline} or ![Next Costume](./blocks/images/block_doWearNextCostume.png){.image-inline} block in a script.
@@ -301,7 +301,7 @@ the action.
 Sometimes it’s desirable to make a sort of “super-sprite” composed of
 pieces that can move together but can also be separately articulated.
 The classic example is a person’s body made up of a torso, limbs, and a
-head. {.snap}`Snap` allows one sprite to be designated as the *anchor*
+head. [Snap!]{.snap} allows one sprite to be designated as the *anchor*
 \index{anchor} of the combined shape, with other sprites as its *parts.*
 \index{parts (of nested sprite)}
 
@@ -380,7 +380,7 @@ Operators palette:
 The `round` block rounds 35.3905… to 35, and the `+` block adds 100 to that.
 (By the way, the `round` block is in the Operators palette, just like `+`,
 but in this script it’s a lighter color with black lettering because
-{.snap}`Snap` alternates light and dark versions of the palette colors when a
+[Snap!]{.snap} alternates light and dark versions of the palette colors when a
 block is nested inside another block from the same palette:
 
 ![image80.png](images/01-blocks-scripts-and-sprites/image80.png) <!-- {width=4.85417in height=1.90625in} -->
@@ -401,7 +401,7 @@ always reports true or false. Predicates\index{Predicate block} have a
 
 The special shape is a reminder that predicates don’t generally make sense
 in an input slot of blocks that are expecting a number or text. You
-wouldn’t say ![image84.png](images/01-blocks-scripts-and-sprites/image84.png), although (as you can see from the picture) {.snap}`Snap` lets
+wouldn’t say ![image84.png](images/01-blocks-scripts-and-sprites/image84.png), although (as you can see from the picture) [Snap!]{.snap} lets
 you do it if you really want. Instead, you normally use predicates in
 special hexagonal input slots like this one:
 
@@ -621,8 +621,8 @@ see how to read information from web sites.
 When you use these
 capabilities, your project may take up a lot of memory\index{memory} in
 the computer. If you get close to the amount of memory available to
-{.snap}`Snap`, then it may become impossible to save your project. (Extra
-space is needed temporarily to convert from {.snap}`Snap`’s internal
+[Snap!]{.snap}, then it may become impossible to save your project. (Extra
+space is needed temporarily to convert from [Snap!]{.snap}’s internal
 representation to the form in which projects are exported or saved.) If
 your program reads a lot of data from the outside world that will still
 be available when you use it next, you might want to have values
@@ -639,7 +639,7 @@ the variable to it.
 
 ## Debugging\index{Debugging}
 
-{.snap}`Snap` provides several tools to help you debug a program. They center
+[Snap!]{.snap} provides several tools to help you debug a program. They center
 around the idea of *pausing* the running of a script partway through, so
 that you can examine the values of variables.
 
@@ -850,7 +850,7 @@ uses case-sensitive comparison, unlike `=`, which is case-independent.
 
 ![image171.png](images/01-blocks-scripts-and-sprites/image171.png){.image-inline} These *hidden* blocks can be found with the relabel option
 \index{relabel option} of any dyadic arithmetic block. They’re hidden
-partly because writing them in {.snap}`Snap` is a good, pretty easy
+partly because writing them in [Snap!]{.snap} is a good, pretty easy
 programming exercise. Note: the two inputs to `atan2`\index{atan2 block}
 are Δ*x* and Δ*y* in that order, because we measure angles clockwise
 from north. `max` /index{max block} and `min` /index{min block} are *variadic;* by clicking the arrowhead, you
@@ -1047,7 +1047,7 @@ script variables if the right input is a script.)
 
 ## Libraries {#sec-libraries-intro}
 
-There are several collections of useful procedures that aren’t {.snap}`Snap`
+There are several collections of useful procedures that aren’t [Snap!]{.snap}
 primitives, but are provided as libraries. To include a library in your
 project, choose the Libraries… option\index{Libraries… option} in the
 file (![file menu icon](images/01-blocks-scripts-and-sprites/image384.png){.image-inline}) menu.
@@ -1202,13 +1202,13 @@ Inexplicably, the designers of Scratch chose to abandon that tradition,
 and to focus on the representation of text as a string of characters.
 The one vestige of the {index}`Logo tradition` from which
 Scratch developed is the block named letter (1) of (world)\index{letter
-(1) of (world) block} , rather than character (1) of (world). {.snap}`Snap`
+(1) of (world) block} , rather than character (1) of (world). [Snap!]{.snap}
 inherits its text handling from Scratch.
 
 In Logo, the visual representation of a sentence\index{visual
 representation of a sentence} (a list of words) looks like a natural
 language sentence: a string of words with spaces between them. In
-{.snap}`Snap`, the visual representation of a list looks nothing at all like
+[Snap!]{.snap}, the visual representation of a list looks nothing at all like
 natural language. On the other hand, representing a sentence as a string
 means that the program must continually re-parse the text on every
 operation, looking for spaces, treating multiple consecutive spaces as
@@ -1245,7 +1245,7 @@ The {index}`pixels library` has one block:
 ![image395.png](images/01-blocks-scripts-and-sprites/image395.png{.image-4x} <!-- {width=0.77917in height=0.62986in} -->
 
 Costumes are first class data
-in {.snap}`Snap`. Most of the processing of costume data is done by primitive
+in [Snap!]{.snap}. Most of the processing of costume data is done by primitive
 blocks in the Looks category. (See page
 [79](#media-computation-with-costumes).) This library provides snap
 \index{snap block}, which takes a picture using your computer’s camera
@@ -1320,7 +1320,7 @@ The colors and {index}`crayons library` has these blocks:
 
 It is intended as a more powerful replacement for the primitive `set pen`
 block\index{set pen block}, including *first class color* support; `HSL color`\index{HSL color} specification as a better alternative to the HSV
-that {.snap}`Snap` inherits from JavaScript; a “{index}`fair hue`”
+that [Snap!]{.snap} inherits from JavaScript; a “{index}`fair hue`”
 scale that compensates for the eye’s grouping a wide range of light
 frequencies as green while labelling mere slivers as orange or yellow;
 the `X11/W3C standard color names`\index{X11/W3C color names}; `RGB in
@@ -1569,7 +1569,7 @@ provides these blocks:\index{case-independent comparisons block}
 ![image463.png](images/01-blocks-scripts-and-sprites/image463.png) <!-- {width=3.9375in height=2.04167in} -->
 
 All
-of these could be written in {.snap}`Snap` itself, but these are implemented
+of these could be written in [Snap!]{.snap} itself, but these are implemented
 using the corresponding JavaScript library functions directly, so they
 run fast. They can be used, for example, in scraping data from a web
 site. The command use case-independent comparisons applies only to this
@@ -1667,7 +1667,7 @@ The {index}`database library` contains these blocks:
 
 ![image472.png](images/01-blocks-scripts-and-sprites/image472.png)
 
-It is used to keep data that persist from one {.snap}`Snap` session
+It is used to keep data that persist from one [Snap!]{.snap} session
  to the next, if you use the same browser and the same login.
 
 The world {index}`map library` has these blocks:
@@ -1747,7 +1747,7 @@ to take lists as inputs. See @sec-ask-lists.
 
 ![image486.png](images/01-blocks-scripts-and-sprites/image486.png)
 
-The **Sci{.snap}`Snap` library**\index{SciSnap@"SciSnap! library"} and the **TuneScope
+The **[SciSnap!]{.snap} library**\index{SciSnap@"SciSnap! library"} and the **TuneScope
 library**\index{TuneScope@"TuneScope library"} are too big to discuss here and are
 documented separately at
 <http://emu-online.de/ProgrammingWithSciSnap.pdf> and

--- a/02-saving-and-loading-projects-and/index.md
+++ b/02-saving-and-loading-projects-and/index.md
@@ -1,9 +1,9 @@
 # Saving and Loading Projects and Media {#sec-ch02}
 
 After you’ve created a project, you’ll want to save it, so that you can
-have access to it the next time you use {.snap}`Snap`. There are two ways to
+have access to it the next time you use [Snap!]{.snap}. There are two ways to
 do that. You can save a project on your own computer, or you can save it
-at the {.snap}`Snap` web site. The advantage of saving on the net is that you
+at the [Snap!]{.snap} web site. The advantage of saving on the net is that you
 have access to your project even if you are using a different computer,
 or a mobile device such as a tablet or smartphone. The advantage of
 saving on your computer is that you have access to the saved project
@@ -16,14 +16,14 @@ In either case, if you choose "`Save as…`" from the File menu. You’ll see so
 ![image487.png](assets/image487.png){#fig-saveas}
 <!--  style="width:3.54861in;height:2.57639in" / -->
 
-(If you are not logged in to your {.snap}`Snap` cloud account, Computer will
+(If you are not logged in to your [Snap!]{.snap} cloud account, Computer will
 be the only usable option.) The text box at the bottom right of the Save
 dialog allows you to enter project notes that are saved with the
 project.
 
 ## Local Storage
 
-Click on Computer and {.snap}`Snap`’s Save Project dialog window will be
+Click on Computer and [Snap!]{.snap}’s Save Project dialog window will be
 replaced by your operating system’s standard save window. If your
 project has a name, that name will be the default filename if you don’t
 give a different name. Another, equivalent way to save to disk is to
@@ -33,7 +33,7 @@ choose "`Export project`" from the File menu.
 
 The other possibility is to
 save your project "`in the cloud`",\index{save your project in the cloud}
-at the {.snap}`Snap` web site. In order to do this, you need an account with
+at the [Snap!]{.snap} web site. In order to do this, you need an account with
 us. Click on the {index}`Cloud button` (![image489.png](assets/image489.png) <!--  style="width:0.29167in;height:0.16667in" / --> ) in the Tool Bar.
 Choose the “`Signup…`” option. This will show you a window that looks like
 the picture below:
@@ -42,7 +42,7 @@ the picture below:
 
 You must choose a {index}`user name` that will identify you on
 the web site, such as `Jens`. If you’re a Scratch user, you can use
-your Scratch name for {.snap}`Snap` too. If you’re a kid, don’t pick a user
+your Scratch name for [Snap!]{.snap} too. If you’re a kid, don’t pick a user
 name that includes your family name, but first names or initials are
 okay. Don’t pick something you’d be embarrassed to have other users (or
 your parents) see! If the name you want is already taken, you’ll have to
@@ -51,7 +51,7 @@ choose another one. You must also supply a password.
 We ask for your month and year of birth; we use this information only to
 decide whether to ask for your own email address or your parent’s email
 address. (If you’re a kid, you shouldn’t sign up for anything on the
-net, not even {.snap}`Snap`, without your parent’s knowledge.) We do not store
+net, not even [Snap!]{.snap}, without your parent’s knowledge.) We do not store
 your birthdate information on our server; it is used on your own
 computer only during this initial signup. We do not ask for your *exact*
 birthdate, even for this one-time purpose, because that’s an important
@@ -72,7 +72,7 @@ Service}. A quick summary: Don’t interfere with anyone else’s use of
 the web site, and don’t put copyrighted media or personally identifiable
 information in projects that you share with other users. And we’re not
 responsible if something goes wrong. (Not that we *expect* anything to
-go wrong; since {.snap}`Snap` runs in JavaScript in your browser, it is
+go wrong; since [Snap!]{.snap} runs in JavaScript in your browser, it is
 strongly isolated from the rest of your computer. But the lawyers make
 us say this.)
 
@@ -85,7 +85,7 @@ option from the Cloud menu:
 
 Use the user name and password that you set up earlier. If you check the
 "`Stay signed in`" box, then you will be logged in automatically the next
-time you run {.snap}`Snap` from the same browser on the same computer. Check
+time you run [Snap!]{.snap} from the same browser on the same computer. Check
 the box if you’re using your own computer and you don’t share it with
 siblings. *Don’t* check the box if you’re using a public computer at the
 library, at school, etc.
@@ -99,9 +99,9 @@ to other users if you publish your project.
 ## Loading Saved Projects\index{loading saved projects}
 
 Once you’ve saved a project, you want to be able to load it back into
-{.snap}`Snap`. There are two ways to do this:
+[Snap!]{.snap}. There are two ways to do this:
 
-1. If you saved the project in your online {.snap}`Snap` account, choose the
+1. If you saved the project in your online [Snap!]{.snap} account, choose the
 "`Open…`" option from the File menu. Choose the "`Cloud`" button, then
 select your project from the list in the big text box and click "`OK`", or
 choose the "`Computer`" button to open an operating system open dialog. (A
@@ -113,32 +113,32 @@ it and reading its project notes.)
 "`Import…`" from the File menu. This will give you an ordinary browser
 file-open window, in which you can navigate to the file as you would in
 other software. Alternatively, find the XML file on your desktop, and
-just drag it onto the {.snap}`Snap` window.
+just drag it onto the [Snap!]{.snap} window.
 
 The second technique above also allows you to import media (costumes and
 sounds) into a project. Just choose "`Import…`" and then select a picture
 or sound file instead of an XML file.
 
-{.snap}`Snap` can also import projects created in BYOB 3.0 or 3.1, or (with
+[Snap!]{.snap} can also import projects created in BYOB 3.0 or 3.1, or (with
 some effort; see our web site) in Scratch 1.4, 2.0 or 3.0. Almost all
-such projects work correctly in {.snap}`Snap`, apart from a small number of
+such projects work correctly in [Snap!]{.snap}, apart from a small number of
 incompatible blocks.
 
-If you saved projects in an earlier version of {.snap}`Snap` using the
+If you saved projects in an earlier version of [Snap!]{.snap} using the
 "`Browser`" option, then a Browser button will be shown in the Open dialog
 to allow you to retrieve those projects. But you can save them only with
 the Computer and Cloud options.
 
 ## If you lose your project, do this first!
 
-If you are still in **{.snap}`Snap`** and realize that you’ve loaded another
+If you are still in **[Snap!]{.snap}** and realize that you’ve loaded another
 project without saving the one you were working on: ***Don’t edit the
 new project.*** From the File menu ![image384.png](assets/image384.png) <!--  style="width:0.31944in;height:0.18056in" alt="Macintosh HD:Users:bh:Desktop:Dropbox:manual (1):filebutton.png" / --> choose the "`Restore unsaved project`"
 option\index{Restore unsaved project option}.
 
-Restore unsaved project will also work if you log out of {.snap}`Snap` and
+Restore unsaved project will also work if you log out of [Snap!]{.snap} and
 later log back in, as long as you don’t edit another project meanwhile.
-{.snap}`Snap` remembers only the most recent project that you’ve edited (not
+[Snap!]{.snap} remembers only the most recent project that you’ve edited (not
 just opened, but actually changed in the project editor).
 
 If your project on the cloud is missing, empty, or otherwise broken and
@@ -152,7 +152,7 @@ that you actually saved, so Restore unsaved project is your first choice
 if you switch away from a project without saving it.
 
 To help you remember to save your projects, when you’ve edited the
-project and haven’t yet saved it, {.snap}`Snap` displays a pencil icon to the
+project and haven’t yet saved it, [Snap!]{.snap} displays a pencil icon to the
 left of the project name on the toolbar at the top of the window:
 
 <!-- TODO: MISSING FILE -->
@@ -164,7 +164,7 @@ By default, a project you save in the cloud is private; only you can see
 it. There are two ways to make a project available to others. If you
 share a project, you can give your friends a project URL (in your
 browser’s URL bar after you open the project) they can use to read it.
-If you publish a project, it will appear on the {.snap}`Snap` web site, and
+If you publish a project, it will appear on the [Snap!]{.snap} web site, and
 the whole world can see it. In any case, nobody other than you can ever
 overwrite your project; if others ask to save it, they get their own
 copy in their own account.

--- a/03-building-a-block/index.md
+++ b/03-building-a-block/index.md
@@ -1,6 +1,6 @@
 # Building a Block {#sec-ch03}
 
-The first version of {.snap}`Snap` was called BYOB, for “Build Your Own Blocks\index{Build Your Own Blocks}.” This was the first and is still the
+The first version of [Snap!]{.snap} was called BYOB, for “Build Your Own Blocks\index{Build Your Own Blocks}.” This was the first and is still the
 most important capability we added to Scratch\index{Scratch}. (The
 name was changed because a few teachers have no sense of humor. ☹ You
 pick your battles.) Scratch 2.0 and later also has a partial custom
@@ -211,9 +211,9 @@ you check or uncheck all the boxes at once.) Then press "`OK`" An [XML]{.mono} f
 containing the blocks will appear in your Downloads location.
 
 To import a block library, use the "`Import…`" command in the "`File`" menu,
-or just drag the [XML]{.mono} file into the {.snap}`Snap` window.
+or just drag the [XML]{.mono} file into the [Snap!]{.snap} window.
 
-Several block libraries are included with {.snap}`Snap`; for details about
+Several block libraries are included with [Snap!]{.snap}; for details about
 them, see @sec-libraries-intro.
 
 ## Custom blocks and Visible Stepping

--- a/04-first-class-lists/index.md
+++ b/04-first-class-lists/index.md
@@ -25,15 +25,15 @@ Scratch reporters reports a list value. (You can use a reduction of the
 list into a text string as input to other blocks, but this loses the
 list structure; the input is just a text string, not a data aggregate.)
 
-A fundamental {index}`design principle` in Snap*!* is
+A fundamental {index}`design principle` in [Snap!]{.snap} is
 that ***<u>all data should be ﬁrst class</u>**.* If it’s in the
 language, then we should be able to use it fully and freely. We believe
 that this principle avoids the need for many special-case tools, which
-can instead be written by Snap*!* users themselves.
+can instead be written by [Snap!]{.snap} users themselves.
 
 Note that it’s a data *type*
 that’s ﬁrst class, not an individual value. Don’t think, for example,
-that some lists are ﬁrst class, while others aren’t. In Snap*!*, lists
+that some lists are ﬁrst class, while others aren’t. In [Snap!]{.snap}, lists
 are ﬁrst class, period.
 
 ![image523.png](assets/image523.png) <!--  style="width:2.83958in;height:0.41597in" / -->
@@ -57,7 +57,7 @@ input to many other blocks:
 
 ![image629.png](assets/image629.png) <!--  style="width:2.83958in;height:0.41597in" / -->
 
-Snap*!* does not have a “`Make
+[Snap!]{.snap} does not have a “`Make
 a list`” button like the one in Scratch \index{Scratch}. If you want a
 global “named list,” make a global variable and use the `set` block to put
 a list into the variable.
@@ -100,7 +100,7 @@ As an example, here are two blocks that take a list of numbers as input,
 and report a new list containing only the even numbers from the original
 list:[^primitives]
 
-[^primitives]: Note to users of earlier versions: From the beginning, there has been a tension in our work between the desire to provide tools such as `for` (used in this example) and the higher order functions introduced on the next page as primitives, to be used as easily as other primitives, and the desire to show how readily such tools can be implemented in Snap! itself. This is one instance of our general pedagogic understanding that learners should both use abstractions and be permitted to see beneath the abstraction barrier. Until version 5.0, we used the uneasy compromise of a library of tools written in Snap! and easily, but not easily enough, loaded into a project. By not loading the tools, users or teachers could explore how to program them. In 5.0 we made them true primitives, partly because that’s what some of us wanted all along and partly because of the increasing importance of fast performance as we explore “big data” and media computation. In version 10.0 we introduced “hybrid” primitives, implemented in high speed Javascript but with an “Edit” option that will open, not the primitive implementation, but the version written in Snap*!*. This gives us editable primitives without dramatically slowing users’ projects.
+[^primitives]: Note to users of earlier versions: From the beginning, there has been a tension in our work between the desire to provide tools such as `for` (used in this example) and the higher order functions introduced on the next page as primitives, to be used as easily as other primitives, and the desire to show how readily such tools can be implemented in Snap! itself. This is one instance of our general pedagogic understanding that learners should both use abstractions and be permitted to see beneath the abstraction barrier. Until version 5.0, we used the uneasy compromise of a library of tools written in Snap! and easily, but not easily enough, loaded into a project. By not loading the tools, users or teachers could explore how to program them. In 5.0 we made them true primitives, partly because that’s what some of us wanted all along and partly because of the increasing importance of fast performance as we explore “big data” and media computation. In version 10.0 we introduced “hybrid” primitives, implemented in high speed Javascript but with an “Edit” option that will open, not the primitive implementation, but the version written in [Snap!]{.snap}. This gives us editable primitives without dramatically slowing users’ projects.
 
 ![image632.png](assets/image632.png) <!--  style="width:5.88889in;height:1.04861in" / -->
 
@@ -134,7 +134,7 @@ block}), which are handled through a recursive call:
 
 ![image555.png](assets/image555.png) <!--  style="width:4.75in;height:2.24097in" / -->
 
-Snap*!*
+[Snap!]{.snap}
 uses two different internal representations of lists, one (dynamic
 \index{array, dynamic} array\index{dynamic array}) for imperative
 programming and the other (linked\index{list, linked} list\index{linked list})
@@ -183,7 +183,7 @@ function}).
 ![image635.png](assets/image635.png) <!--  style="width:2.375in;height:0.27778in" / -->
 
 
-Snap*!* provides four higher order function blocks for operating on
+[Snap!]{.snap} provides four higher order function blocks for operating on
 lists:
 
 ![image636.png](assets/image636.png){.image-4x}
@@ -319,14 +319,14 @@ Beyond such simple cases, in which every item of the main list is a list
 of the same length, it’s important to keep in mind that the design of
 table view has to satisfy two goals, not always in agreement: (1) a
 visually compelling display of two-dimensional arrays, and (2) highly
-efficient display generation, so that Snap*!* can handle very large
+efficient display generation, so that [Snap!]{.snap} can handle very large
 lists, since “big data” is an important topic of study. To meet the
 first goal perfectly in the case of “ragged right” arrays in which
-sublists can have different lengths, Snap*!* would scan the entire list
+sublists can have different lengths, [Snap!]{.snap} would scan the entire list
 to find the maximum width before displaying anything, but that would
 violate the second goal.
 
-Snap*!* uses the simplest possible compromise between the two goals: It
+[Snap!]{.snap} uses the simplest possible compromise between the two goals: It
 examines only the first ten items of the list to decide on the format.
 If none of those are lists, or they’re all lists of one item, and the
 overall length is no more than 100, list view is used. If the any of
@@ -370,7 +370,7 @@ to fit the entire value in a cell:
 
 ![image601.png](assets/image601.png) <!--  style="width:3.34097in;height:0.57708in" / -->
 
-Even if you expand the size of the cells, Snap*!* will not display
+Even if you expand the size of the cells, [Snap!]{.snap} will not display
 sublists of sublists in table view. There are two ways to see these
 inner sublists: You can switch to list view, or you can double-click on
 a list icon in the table to open a dialog box showing just that
@@ -390,9 +390,9 @@ look almost like a one-column display.
 
 Spreadsheet and database programs generally offer the option to export
 their data as CSV (comma-separated values)\index{CSV (comma-separated
-values)} lists. You can import these files into Snap*!* and turn them
+values)} lists. You can import these files into [Snap!]{.snap} and turn them
 into tables (lists of lists), and you can export tables in CSV format.
-{.snap}`Snap` recognizes a CSV file by the extension .csv in its filename.
+[Snap!]{.snap} recognizes a CSV file by the extension .csv in its filename.
 
 A CSV file has one line per table row, with the fields separated by
 commas within a row:
@@ -413,7 +413,7 @@ Here’s what the corresponding table looks like:
 ![table view](assets/table-view.png)
 ![list view](assets/list-view.png)
 
-Here’s how to read a spreadsheet into Snap*!*:
+Here’s how to read a spreadsheet into [Snap!]{.snap}:
 
 1. Make a variable
 with a watcher on stage: ![image607.png](assets/image607.png) <!-- style="width:1.20833in;height:0.27083in" alt="Macintosh HD:Users:bh:Desktop:pix:watcher.png" -->
@@ -426,12 +426,12 @@ variable’s value is already a list, be sure to click on the outside
 border of the watcher; there is a different menu if you click on the
 list itself.) Select the file with your csv data.
 
-3. There is no 3; that’s it! Snap*!* will notice that the name of the
+3. There is no 3; that’s it! [Snap!]{.snap} will notice that the name of the
 file you’re importing is something`.csv` and will turn the text into a
 list of lists automatically.
 
 Or, even easier, just drag and drop the file from your desktop onto the
-Snap*!* window, and Snap*!* will automatically create a variable named
+[Snap!]{.snap} window, and [Snap!]{.snap} will automatically create a variable named
 after the file and import the data into it.
 
 If you actually want to import the raw CSV data into a variable, either
@@ -445,7 +445,7 @@ right-click an item instead of the border; that gives a different menu.)
 ### Multi-dimensional lists and JSON
 
 CSV format is easy to read, but works only for one- or two-dimensional
-lists. If you have a list of lists of lists, Snap*!* will instead export
+lists. If you have a list of lists of lists, [Snap!]{.snap} will instead export
 your list as a JSON (JavaScript Object Notation) file\index{JSON
 (JavaScript Object Notation) file} . I modified my list:
 
@@ -472,7 +472,7 @@ function} is one whose domain and range are scalars, so all the
 arithmetic operations are scalar functions, but so are the text ones
 such as `letter` and the Boolean ones such as `not`.
 
-The major new feature in Snap*!* 6.0 is that the domain and range of
+The major new feature in [Snap!]{.snap} 6.0 is that the domain and range of
 most scalar function blocks is extended to multi-dimensional
 \index{list, multi-dimensional} lists, with the underlying scalar
 function applied termwise:
@@ -566,7 +566,7 @@ a list as its first (index) input:
 
 3.  If the index is a list of lists of numbers, then `item of` reports an
     array of only those scalars whose position in the list input matches
-    the index input in all dimensions (as of Snap*!*
+    the index input in all dimensions (as of [Snap!]{.snap}
     6.6):
 
     ![image625.png](assets/image625.png) <!--  style="width:6.00694in;height:0.6875in" / -->
@@ -579,7 +579,7 @@ a list as its first (index) input:
 
  To
 get a column or columns of a spreadsheet, use an empty list in the row
-selector (as of Snap*!* 6.6):
+selector (as of [Snap!]{.snap} 6.6):
 
 ![image627.png](assets/image627.png) <!--  style="width:6.60417in;height:1.04861in" alt="Graphical user interface, application, website Description automatically generated" / -->
 
@@ -637,7 +637,7 @@ include arrays comes from the language APL\index{APL}. (All the great
 programming languages are based on mathematical ideas. Our primary
 ancestors are Smalltalk\index{Smalltalk}, based on models, and Lisp
 \index{Lisp}, based on lambda calculus. Prolog\index{Prolog}, a great
-language not (so far) influencing Snap*!*, is based on logic. And APL,
+language not (so far) influencing [Snap!]{.snap}, is based on logic. And APL,
 now joining our family, is based on linear algebra, which studies
 vectors and matrices. Those *other* programming languages are based on
 the weaknesses of computer hardware.) Hyperblocks are not the whole

--- a/05-typed-inputs/index.md
+++ b/05-typed-inputs/index.md
@@ -8,12 +8,12 @@ indicated by a rectangular box, the latter by a rounded box: ![image654.png](ass
 Scratch type, [Boolean]{.mono} (true/false), can be used in certain [Control]{.mono}
 blocks with hexagonal slots.
 
-The {.snap}`Snap` types are an expanded collection including [Procedure]{.mono}, [List]{.mono},
+The [Snap!]{.snap} types are an expanded collection including [Procedure]{.mono}, [List]{.mono},
 and [Object]{.mono} types. Note that, with the exception of [Procedure]{.mono} types, all
 of the input type shapes are just reminders to the user of what the
 block expects; they are not enforced by the language.
 
-## The {.snap}`Snap` Input Type Dialog
+## The [Snap!]{.snap} Input Type Dialog
 
 In the {index}`Block Editor` input name dialog\index{input
 name dialog}, there is a right-facing arrowhead after the "`Input name`"
@@ -46,13 +46,13 @@ The second row of input types
 contains the ones found in Scratch: [Number]{.mono}, [Any]{.mono}, and [Boolean]{.mono}. (The
 reason these are in the second row rather than the ﬁrst will become
 clear when we look at the column arrangement.) The ﬁrst row contains the
-new {.snap}`Snap` types other than procedures: [Object]{.mono}, [Text]{.mono}, and [List]{.mono}. The
+new [Snap!]{.snap} types other than procedures: [Object]{.mono}, [Text]{.mono}, and [List]{.mono}. The
 last two rows are the types related to procedures, discussed more fully
 below.
 
 The [List]{.mono} type\index{List type} is used for ﬁrst class lists, discussed
 in Chapter IV above. The red rectangles inside the input slot are meant
-to resemble the appearance of lists as {.snap}`Snap` displays them on the
+to resemble the appearance of lists as [Snap!]{.snap} displays them on the
 stage: each element in a red rectangle.
 
 The [Object]{.mono} type\index{Object type} is for sprites, costumes, sounds,
@@ -76,11 +76,11 @@ in the input type selection box.)
 
 Although the procedure types are discussed more fully later, they are
 the key to understanding the column arrangement in the input types. Like
-Scratch, {.snap}`Snap` has three {index}`block shapes` :
+Scratch, [Snap!]{.snap} has three {index}`block shapes` :
 jigsaw-piece\index{jigsaw-piece blocks} for command blocks, oval
 \index{oval blocks} for reporters, and hexagonal\index{hexagonal
 blocks} for predicates. (A *predicate* is a reporter that always reports
-true or false.) In {.snap}`Snap` these blocks are ﬁrst class data; an input to
+true or false.) In [Snap!]{.snap} these blocks are ﬁrst class data; an input to
 a block can be of Command type, Reporter type, or Predicate type. Each
 of these types is directly below the type of value that that kind of
 block reports, except for Commands, which don’t report a value at all.
@@ -199,10 +199,10 @@ name “size” and default value 10 looks like this:
 
 The "`Multiple inputs`" option:
 The <code>list</code> block introduced earlier accepts any number of inputs to
-specify the items of the new list. To allow this, {.snap}`Snap` introduces the
+specify the items of the new list. To allow this, [Snap!]{.snap} introduces the
 arrowhead notation (⏴⏵) that expands and contracts the block, adding and
 removing input slots. ([Shift-clicking]{.mono} on an arrowhead adds or removes
-three input slots at once.) Custom blocks made by the {.snap}`Snap` user have
+three input slots at once.) Custom blocks made by the [Snap!]{.snap} user have
 that capability, too. If you choose the "`Multiple inputs`" button, then
 arrowheads\index{arrowheads} will appear after the input slot in the
 block. More or fewer slots (as few as zero) may be used. When the block
@@ -234,7 +234,7 @@ an *upvar*\index{upvar} for short, because it is passed *upward* from
 the custom block to the script that uses it.
 
 Note about the example: <code>for</code> is a primitive block, but it doesn’t need to
-be. You’re about to see (next chapter) how it can be written in {.snap}`Snap`.
+be. You’re about to see (next chapter) how it can be written in [Snap!]{.snap}.
 Just give it a different name to avoid confusion, such as <code>my for</code> as
 above.
 
@@ -272,7 +272,7 @@ is the arrowhead that has appeared at the right end of the text box.
 Click it to see the menu shown here at the left.
 
 Choose one of the symbols. The result will have the symbol you want: ![image688.png](assets/image688.png){.image-inline}. The
-available symbols are, pretty much, the ones that are used in {.snap}`Snap`
+available symbols are, pretty much, the ones that are used in [Snap!]{.snap}
 icons.
 
  But I’d like the arrow symbol
@@ -292,5 +292,5 @@ will make a huge orange <code>foo</code>.
 
 Note the last entry in the symbol menu: "`new line`"\index{new line
 character}. This can be used in a block with many inputs to control
-where the text continues on another line, instead of letting {.snap}`Snap`
+where the text continues on another line, instead of letting [Snap!]{.snap}
 choose the line break itself.

--- a/06-procedures-as-data/index.md
+++ b/06-procedures-as-data/index.md
@@ -6,7 +6,7 @@
 
 In the {index}`for block` example above, the input named <var>action</var> has been declared as type
 "`Command (C-shaped)`"; that’s why the finished block is C-shaped. But how
-does the block actually tell {.snap}`Snap` to carry out the commands inside
+does the block actually tell [Snap!]{.snap} to carry out the commands inside
 the C-slot? Here is a simple version of the block script:
 
 ![image692.png](assets/image692.png)
@@ -18,13 +18,13 @@ the variable by −1 for each repetition instead of by 1.
 
 The
 important part of this script is the {index}`\`run\` block<`run` block>` near
-the end. This is a {.snap}`Snap` built-in command block that takes a
+the end. This is a [Snap!]{.snap} built-in command block that takes a
 Command-type value (a script) as its input, and carries out its
 instructions. (In this example, the value of the input ![image693.png](assets/image693.png) <!--  style="width:0.5in;height:0.15625in" / --> is the script
 that the user puts in the C-slot of the `my for` block.) There is a
 similar `call` reporter block for invoking a Reporter or Predicate block.
 The `call`\index{call block } and `run` blocks are at the heart of
-{.snap}`Snap`’s ﬁrst class procedure\index{first class procedures} feature;
+[Snap!]{.snap}’s ﬁrst class procedure\index{first class procedures} feature;
 they allow scripts and blocks to be used as data—in this example, as an
 input to a block—and eventually carried out under control of the user’s
 program.
@@ -105,7 +105,7 @@ definition of the `my for` block (see @sec-call-and-run) doesn’t have a
 `ring` around its input variable <var>action</var>. When you drag a variable into a
 ringed input slot, you generally *do* want to use *the value of* the
 variable, which will be the block or script you’re trying to run or
-call, rather than the orange variable reporter itself. So {.snap}`Snap`
+call, rather than the orange variable reporter itself. So [Snap!]{.snap}
 automatically removes the ring in this case. If you ever do want to use
 the variable *block itself,* rather than the value of the variable, as a
 Procedure-type input, you can drag the variable into the input slot,
@@ -113,7 +113,7 @@ then control-click or right-click it and choose "`ringify`" from the menu
 that appears. (Similarly, if you ever want to call a function that will
 report a block to use as the input, such as `item (1) of ( ) ` applied to a list
 *of blocks,* you can choose "`unringify`" from the menu. Almost all the
-time, though, {.snap}`Snap` does what you mean without help.)
+time, though, [Snap!]{.snap} does what you mean without help.)
 
 ## Writing Higher Order Procedures
 
@@ -135,7 +135,7 @@ Why would you want a block to take a procedure as input? This is actually
 not an obscure thing to do; the primitive conditional and looping blocks
 (the C-shaped ones in the Control palette) take a script as input. Users
 just don’t usually think about it in those terms! We could write the
-{index}`\`repeat\` block<`repeat` block>` as a custom block this way, if {.snap}`Snap`
+{index}`\`repeat\` block<`repeat` block>` as a custom block this way, if [Snap!]{.snap}
 didn’t already have one:
 
 ![image708.png](assets/image708.png) <!--  style="width:2.375in;height:1.35417in" / -->
@@ -186,23 +186,23 @@ use a specific, literal script as the input. Instead, the input will
 generally be a variable whose *value* is a script.
 
 The `run` and `call` blocks have arrowheads at the end that can be used to
-open slots for inputs to the called procedures. How does {.snap}`Snap` know
+open slots for inputs to the called procedures. How does [Snap!]{.snap} know
 where to use those inputs? If the called procedure (block or script) has
-empty input slots, {.snap}`Snap` “does the right thing.” This has several
+empty input slots, [Snap!]{.snap} “does the right thing.” This has several
 possible meanings:
 
 1. If the number of empty slots\index{empty input slots, filling} is exactly equal to the number
-of inputs provided, then {.snap}`Snap` fills the empty slots from left to
+of inputs provided, then [Snap!]{.snap} fills the empty slots from left to
 right:
 
 ![image711.png](assets/image711.png) <!--  style="width:3.44792in;height:0.34406in" / -->
 
-2. If exactly one input is provided, {.snap}`Snap` will fill any number of
+2. If exactly one input is provided, [Snap!]{.snap} will fill any number of
 empty slots with it:
 
 ![image712.png](assets/image712.png) <!--  style="width:2.80208in;height:0.30694in" / -->
 
-3. Otherwise, {.snap}`Snap` won’t fill any slots, because the user’s
+3. Otherwise, [Snap!]{.snap} won’t fill any slots, because the user’s
 intention is unclear.
 
 If the user wants to override these rules, the solution is to use a `ring`
@@ -276,7 +276,7 @@ the `ring`:
 ![image731.png](assets/image731.png) <!--  style="width:4.32292in;height:0.45417in" / -->
 
 Here we just want to put one of the inputs into two different slots. If
-we left all three slots empty, {.snap}`Snap` would not fill any of them,
+we left all three slots empty, [Snap!]{.snap} would not fill any of them,
 because the number of inputs provided (2) would not match the number of
 empty slots (3).
 
@@ -299,11 +299,11 @@ must give an explicit name, <var>newitem</var>, to the value that the outer `map
 giving to the inner one, then drag that variable into the `( ) in front of ( )`
 block.
 
-By the way, once the called block provides names for its inputs, {.snap}`Snap`
+By the way, once the called block provides names for its inputs, [Snap!]{.snap}
 will not automatically fill empty slots\index{empty input slots,
 filling}, on the theory that the user has taken control. In fact,
 that’s another reason you might want to name the inputs explicitly: to
-stop {.snap}`Snap` from filling a slot that should really remain empty.
+stop [Snap!]{.snap} from filling a slot that should really remain empty.
 
 ## Procedures as Data
 
@@ -334,7 +334,7 @@ reports a procedure):
 \index{if else block } block has two C-shaped command slots and chooses
 one or the other depending on a Boolean test. Because Scratch doesn’t
 emphasize functional programming, it lacks a corresponding reporter
-block to choose between two expressions. {.snap}`Snap` has one, but we could
+block to choose between two expressions. [Snap!]{.snap} has one, but we could
 write our own:
 
 <!-- TODO: The 2 + 1 layout is kind of a special case. -->
@@ -415,7 +415,7 @@ it works internally.
 
 ### Special Forms in Scratch
 
-Special forms are actually not a new invention in {.snap}`Snap`. Many of
+Special forms are actually not a new invention in [Snap!]{.snap}. Many of
 Scratch’s conditional and looping blocks are really special forms. The
 hexagonal input slot in the `if` block is a straightforward Boolean value,
 because the value can be computed once, before the `if` block makes its
@@ -425,7 +425,7 @@ have to be of type “Boolean (unevaluated)\index{Boolean (unevaluated)
 type},” so that Scratch can evaluate them over and over again. Since
 Scratch doesn’t have custom C‑shaped blocks, it can afford to handwave
 away the distinction between evaluated and unevaluated Booleans, but
-{.snap}`Snap` can’t. The pedagogic value of special forms is proven by the
+[Snap!]{.snap} can’t. The pedagogic value of special forms is proven by the
 fact that no Scratcher ever notices that there’s anything strange about
 the way in which the hexagonal inputs in the [Control]{.mono} blocks are
 evaluated.

--- a/07-object-oriented-programming-with-sprites/index.md
+++ b/07-object-oriented-programming-with-sprites/index.md
@@ -14,7 +14,7 @@ emphasize the *simulation* aspect (in which each object abstractly
 represents something in the world, and the interactions of objects in
 the program model real interactions of real people or things). Data
 hiding is important for large multi-programmer industrial projects, but
-for {.snap}`Snap` users it’s the simulation\index{simulation} aspect that’s
+for [Snap!]{.snap} users it’s the simulation\index{simulation} aspect that’s
 important. Our approach is therefore less restrictive than that of some
 other [OOP]{.mono} languages; we give objects easy access to each others’ data
 and methods.
@@ -40,7 +40,7 @@ programmed explicitly.
 
 ##  First Class Sprites
 
-Like Scratch, {.snap}`Snap` comes with things that are natural objects: its
+Like Scratch, [Snap!]{.snap} comes with things that are natural objects: its
 sprites\index{sprite}. Each sprite can own local variables; each
 sprite has its own scripts (methods). A Scratch animation is plainly a
 simulation of the interaction of characters in a play. There are two
@@ -53,7 +53,7 @@ paradigm objects are *data;* they can be the value of a variable, an
 element of a list, and so on, but that’s not the case for Scratch
 sprites.
 
-{.snap}`Snap` sprites are first class\index{first class sprites} data. They can
+[Snap!]{.snap} sprites are first class\index{first class sprites} data. They can
 be created and deleted by a script, stored in a variable or list, and
 sent messages individually. The children of a sprite can inherit
 sprite-local variables, methods (sprite-local procedures), and other
@@ -112,11 +112,11 @@ of <var>Cocker Spaniel</var> (so there are four altogether) and two clones of
 breed in particular. Each dog has its own position, special behaviors,
 and so on. You want to save all of these dogs in the project. These are
 *[permanent]{.mono}* clones\index{permanent clone}. In [BYOB 3.1]{.mono}, the
-predecessor to {.snap}`Snap`, all clones\index{clone!permanent} are
+predecessor to [Snap!]{.snap}, all clones\index{clone!permanent} are
 permanent.
 
  One advantage
-of temporary clones is that they don’t slow down {.snap}`Snap` even when you
+of temporary clones is that they don’t slow down [Snap!]{.snap} even when you
 have a lot of them. (If you’re curious, one reason is that permanent
 clones appear in the sprite corral, where their pictures have to be
 updated to reflect the clone’s current costume, direction, and so on.)
@@ -174,10 +174,10 @@ continue without waiting. For this purpose we have the <code>launch ( )</code> b
 
 <code>Launch ( )</code> is analogous to <code>broadcast</code> without the “wait.”
 
-{.snap}`Snap` [4.1]{.mono}, following [BYOB 3.1]{.mono}, used an extension of the of block to
+[Snap!]{.snap} [4.1]{.mono}, following [BYOB 3.1]{.mono}, used an extension of the of block to
 provide access to other sprites’ methods. That interface was designed
 back when we were trying hard to avoid adding new primitive blocks; it
-allowed us to write <code>ask ( ) and wait</code> and <code>tell ( )</code> as tool procedures in {.snap}`Snap` itself.
+allowed us to write <code>ask ( ) and wait</code> and <code>tell ( )</code> as tool procedures in [Snap!]{.snap} itself.
 That technique still works, but is deprecated, because nobody understood
 it, and now we have the more straightforward primitives.
 
@@ -243,7 +243,7 @@ The block, if any, that examines a variable or attribute
 may be more than one, as in the direction example above) that modifies a
 variable or attribute is called a\index{setter} *setter.*
 
-In {.snap}`Snap` we allow virtually all attributes to be examined. But instead
+In [Snap!]{.snap} we allow virtually all attributes to be examined. But instead
 of adding dozens of reporters, we use a more uniform interface for
 attributes: The {index}`my block`’s menu (in [Sensing]{.mono}; see page
 [78](#attrib.pnglist-of-attributes)) includes many of the attributes of
@@ -263,7 +263,7 @@ objects. A class is a particular *kind of object,* and an instance is an
 and several instances Fido, Spot, and Runt. The class typically
 specifies the methods shared by all dogs (RollOver, SitUpAndBeg, Fetch,
 and so on), and the instances contain data such as species, color, and
-friendliness. {.snap}`Snap` uses a different approach called *prototyping,* in
+friendliness. [Snap!]{.snap} uses a different approach called *prototyping,* in
 which there is no distinction between classes and instances. Prototyping
 \index{prototyping} is better suited to an experimental, tinkering style
 of work: You make a single dog sprite, with both methods (blocks) and

--- a/08-oop-with-procedures/index.md
+++ b/08-oop-with-procedures/index.md
@@ -73,7 +73,7 @@ do both procedure calls in one:
 ![image854.png](assets/image854.png){.image-4x} <!--  style="width:4.01042in;height:0.70772in" / -->
 
 The <code>ask</code> block\index{ask block} has two required inputs: an object and a
-message. It also accepts optional additional inputs, which {.snap}`Snap` puts
+message. It also accepts optional additional inputs, which [Snap!]{.snap} puts
 in a list; that list is named <var>args</var> inside the block. <code>Ask</code> has two nested
 call blocks. The inner one calls the object, i.e., the dispatch
 procedure. The dispatch procedure always takes exactly one input, namely
@@ -128,7 +128,7 @@ gets a private copy. (If a child wants to change something for its
 entire family, it must ask the parent to do it.)
 
 Because we want to be able to create and delete properties dynamically,
-we won’t use {.snap}`Snap` variables to hold an object’s variables or methods.
+we won’t use [Snap!]{.snap} variables to hold an object’s variables or methods.
 Instead, each object has two *tables,* called **methods** and **data**, each of
 which {index}`is an` *association list:* a list of
 two-item lists, in which each of the latter contains a *key* and a

--- a/09-the-outside-world/index.md
+++ b/09-the-outside-world/index.md
@@ -4,7 +4,7 @@ The facilities discussed so far are fine for projects that take place
 entirely on your computer’s screen. But you may want to write programs
 that interact with physical devices\index{devices} (sensors
 \index{sensors} or robots\index{robots} ) or with the World Wide Web
-\index{World Wide Web}. For these purposes {.snap}`Snap` provides a
+\index{World Wide Web}. For these purposes [Snap!]{.snap} provides a
 single primitive block:
 
 ![image148.png](../blocks/images/block_reportURL.png)
@@ -38,7 +38,7 @@ through only 100 items at a time. The downarrow near the bottom right
 corner of the speech balloon in the picture presents a menu of
 hundred-item ranges. (This may seem unnecessary, since the scroll bar
 should allow for any number of items, but doing it this way makes
-{.snap}`Snap` much faster.) In table view, the entire list is included.
+[Snap!]{.snap} much faster.) In table view, the entire list is included.
 
 If you include a protocol name in the input to the url block (such as
 `http://` or `https://`), that protocol will be used. If not, the block
@@ -58,16 +58,16 @@ JavaScript and that forward your requests.
 
 ## Hardware Devices
 
-Another JavaScript security restriction prevents {.snap}`Snap` from having
+Another JavaScript security restriction prevents [Snap!]{.snap} from having
 direct access to devices\index{devices} connected to your computer,
 such as sensors and robots\index{robots}. (Mobile devices such as
 smartphones may also have useful devices built in, such as
 accelerometers and GPS receivers.) The url block is also used to
-interface {.snap}`Snap` with these external capabilities.
+interface [Snap!]{.snap} with these external capabilities.
 
 The idea is that you run a separate program that both interfaces with
-the device and provides a local HTTP server that {.snap}`Snap` can use to make
-requests to the device. *Unlike* {.snap}`Snap` *itself, these programs have
+the device and provides a local HTTP server that [Snap!]{.snap} can use to make
+requests to the device. *Unlike* [Snap!]{.snap} *itself, these programs have
 access to anything on your computer, so you have to trust the author of
 the software!* Our web site, snap.berkeley.edu, provides links to
 drivers for several devices, including, at this writing, the Lego NXT

--- a/10-continuations/index.md
+++ b/10-continuations/index.md
@@ -90,9 +90,9 @@ using the empty-slot notation for input substitution.
 ## Continuation Passing Style
 
 Like all\index{continuation passing style} programming languages,
-{.snap}`Snap` evaluates compositions of nested reporters from the inside out.
+[Snap!]{.snap} evaluates compositions of nested reporters from the inside out.
 For example, in the expression
-![image884.png](assets/image884.png) <!--  style="width:1.3125in;height:0.22917in" / --> {.snap}`Snap`
+![image884.png](assets/image884.png) <!--  style="width:1.3125in;height:0.22917in" / --> [Snap!]{.snap}
 first adds 4 and 5, then multiplies 3 by that sum. This often means that
 the order in which the operations are done is backwards from the order
 in which they appear in the expression: When reading the above
@@ -181,7 +181,7 @@ explicitly CPS if/else block.
 ## Call/Run w/Continuation
 
 To use explicit continuation passing style, we had to define special
-versions of all the reporters, add and so on. {.snap}`Snap` provides a
+versions of all the reporters, add and so on. [Snap!]{.snap} provides a
 primitive mechanism for capturing continuations when we need to, without
 using continuation passing throughout a project.
 
@@ -245,7 +245,7 @@ so that the continuation is saved permanently and can be called from
 anywhere in the project. That’s why the input slot in call
 w/continuation has a Command ring rather than a Reporter ring.
 
-First class continuations are an experimental feature in {.snap}`Snap` and
+First class continuations are an experimental feature in [Snap!]{.snap} and
 there are many known limitations in it. One is that the display of
 reporter continuations shows only the single block in which the call
 w/continuation is an input.
@@ -292,10 +292,10 @@ and the × block multiplies 10 and 20.
 
 **Creating a Thread System**
 
-{.snap}`Snap` can be running several scripts at once, within a single sprite
+[Snap!]{.snap} can be running several scripts at once, within a single sprite
 and across many sprites. If you only have one computer, how can it do
 many things at once? The answer is that only one is actually running at
-any moment, but {.snap}`Snap` switches its attention from one script to
+any moment, but [Snap!]{.snap} switches its attention from one script to
 another frequently. At the bottom of every looping block (repeat, repeat
 until, forever), there is an implicit “yield” command, which remembers
 where the current script is up to, and switches to some other script,
@@ -327,6 +327,6 @@ p,q,r,s,t,u,12,13,v,w,x,y,z,14,15,16,17,18,…30.
 
 ![image928.png](assets/image928.png) <!--  style="width:2.94792in;height:4.25417in" / -->
 
-If we wanted this to behave exactly like {.snap}`Snap`’s own threads, we’d
+If we wanted this to behave exactly like [Snap!]{.snap}’s own threads, we’d
 define new versions of repeat and so on that run yield after each
 repetition.

--- a/11-metaprogramming/index.md
+++ b/11-metaprogramming/index.md
@@ -222,11 +222,11 @@ except that the “procedure” is a macro, with different evaluation rules
 from ordinary procedures. Two things make a macro different: its input
 expressions are not evaluated, so a macro can establish its own syntax
 (but still delimited by parentheses, in Lisp, or still one block, in
-{.snap}`Snap` ); and the result of a macro call is a new expression that is
+[Snap!]{.snap} ); and the result of a macro call is a new expression that is
 evaluated *as if it appeared in the caller* of the macro, with access to
 the caller’s variables and, implicitly, its continuation.
 
-{.snap}`Snap` has long had the first part of this, the ability to make inputs
+[Snap!]{.snap} has long had the first part of this, the ability to make inputs
 unevaluated. In version 8.0 we add the ability to run code in the
 context of another procedure, just as we can run code in the context of
 another sprite, using the same mechanism: the of block\index{of block

--- a/12-user-interface-elements/index.md
+++ b/12-user-interface-elements/index.md
@@ -1,8 +1,8 @@
 # User Interface Elements\index{user interface elements} {#sec-ch12}
 
 In this chapter we describe in detail the various buttons, menus, and
-other clickable elements of the {.snap}`Snap` user interface. Here again is
-the map of the {.snap}`Snap` window:
+other clickable elements of the [Snap!]{.snap} user interface. Here again is
+the map of the [Snap!]{.snap} window:
 
 ![An annotated screenshot of blank Snap! editor](assets/snap-ide-annotated.png)
 
@@ -17,14 +17,14 @@ use by the developers. We’re not listing those extra options here
 because they change frequently and you shouldn’t rely on them. But
 they’re not secrets\index{secrets}.
 
-### The {.snap}`Snap` Logo Menu
+### The [Snap!]{.snap} Logo Menu
 
-The {.snap}`Snap` logo\index{Snap! logo menu} at the left end of the tool bar
-is clickable. It shows a menu of options about {.snap}`Snap` itself:
+The [Snap!]{.snap} logo\index{Snap! logo menu} at the left end of the tool bar
+is clickable. It shows a menu of options about [Snap!]{.snap} itself:
 
 ![Snap! logo menu showing options: About, Reference Manual, Snap! Website and Download Source](assets/image994.png) <!--  style="width:2.32922in;height:1.02in" / -->
 
-The "`About`" option\index{About option} displays information about {.snap}`Snap`
+The "`About`" option\index{About option} displays information about [Snap!]{.snap}
 itself, including version numbers for the source modules, the
 implementors, and the license\index{license} (AGPL\index{AGPL} : you
 can do anything with it except create proprietary versions, basically).
@@ -32,13 +32,13 @@ can do anything with it except create proprietary versions, basically).
 The "`Reference manual`" option\index{Reference manual option} is a link to latest revision of this manual as a web page.
 
 The "`Snap! website`" option\index{"Snap! website option"} opens a browser
-window pointing to [https://snap.berkeley.edu](https://snap.berkeley.edu)\index{snap.berkeley.edu}, the community site for {.snap}`Snap`.
+window pointing to [https://snap.berkeley.edu](https://snap.berkeley.edu)\index{snap.berkeley.edu}, the community site for [Snap!]{.snap}.
 
 The "`Download source`" option\index{Download source option@\texttt{Download source} option} opens a
-browser window displaying the [GitHub repository][github] of the source files for {.snap}`Snap`.\index{"source files for Snap\!"} At the bottom of the page
+browser window displaying the [GitHub repository][github] of the source files for [Snap!]{.snap}.\index{"source files for Snap\!"} At the bottom of the page
 are links to download the latest official release. Or you can navigate
 around the site to find the current development version. You can read
-the code to learn how {.snap}`Snap` is implemented, host a copy on your own
+the code to learn how [Snap!]{.snap} is implemented, host a copy on your own
 computer (this is one way to keep working while on an airplane), or make
 a modified version with customized features. (However, access to cloud
 accounts is limited to the official version hosted at Berkeley.)
@@ -61,7 +61,7 @@ with the project, and is useful if you share it with other users.
 The "`New`" option\index{New option} starts a new, empty project. Any
 project you were working on before disappears, so you are asked to
 confirm that this is really what you want. (It disappears only from the
-current working {.snap}`Snap` window; you should save the current project, if
+current working [Snap!]{.snap} window; you should save the current project, if
 you want to keep it, before using New.)
 
 Note the <kbd>^N</kbd> at the end of the line. This indicates that you can type
@@ -69,7 +69,7 @@ control-N as a shortcut for this menu item. Alas, this is not the case
 in every browser. Some Mac browsers require command-N (<kbd>⌘N</kbd>)
 instead, while others open a new browser window instead of a new project.
 You’ll have to experiment. In general, the keyboard shortcuts
-\index{shortcuts!keyboard} in {.snap}`Snap` are the standard ones you expect
+\index{shortcuts!keyboard} in [Snap!]{.snap} are the standard ones you expect
 in other software.
 
 The "`Open…`" option\index{Open…@\texttt{Open…} option} shows a project open dialog box in
@@ -78,7 +78,7 @@ which you can choose a project to open:
 ![The Open Project Dialog in Snap!](assets/image995.png) <!--  style="width:2.88958in;height:2.09792in" / -->
 
 In this dialog, the three large buttons at the left select a source of
-projects: "`Cloud`"\index{Cloud button} means your {.snap}`Snap` account’s cloud
+projects: "`Cloud`"\index{Cloud button} means your [Snap!]{.snap} account’s cloud
 storage. "`Examples`"\index{Examples button} means a collection of sample
 projects we provide. "`Computer`" is for projects saved on your own
 computer; when you click it, this dialog is replaced with your
@@ -119,7 +119,7 @@ like this one:
 but with your username and project name. (“[`%20`]{.mono}” in the project name
 represents a space, which can’t be part of a URL.) Anyone who knows this
 URL can see your project. Finally, if your project is published (**_bold
-italic_** in the list), then your project is shown on the {.snap}`Snap` web
+italic_** in the list), then your project is shown on the [Snap!]{.snap} web
 site for all the world to see. (In all of these cases, you are the only
 one who can *write* to (save) your project.) If another user saves it, a
 separate copy will be saved in that user’s account. Projects remember
@@ -127,7 +127,7 @@ the history of who created the original version and any other “remix”
 versions along the way.
 
 In the second row, the first button, "`Open`", loads the project into
-{.snap}`Snap` and closes the dialog box. The next button (if "`Cloud`" is the
+[Snap!]{.snap} and closes the dialog box. The next button (if "`Cloud`" is the
 source) is "`Delete`", and if clicked it deletes the selected project.
 Finally, the "`Cancel`" button closes the dialog box without opening a
 project. (It does not undo any sharing, unsharing, or deletion you’ve
@@ -154,18 +154,18 @@ external resource into the current project, or it can load an entirely
 separate project, from your local disk. You can import costumes (any
 picture format that your browser supports), sounds (again, any format
 supported by your browser), and block libraries or sprites (XML format,
-previously exported from {.snap}`Snap` itself). Imported costumes and sounds
+previously exported from [Snap!]{.snap} itself). Imported costumes and sounds
 will belong to the currently selected sprite; imported blocks are global
 (for all sprites). Using the "`Import`" option is equivalent to dragging the
-file from your desktop onto the {.snap}`Snap` window.
+file from your desktop onto the [Snap!]{.snap} window.
 
 <!-- TODO: Update to default to downloading an XML file. -->
 Depending on your browser, the "`Export project…`" option either directly
 saves to your disk or\index{Export project… option} opens a new browser
 tab containing your complete project in XML notation (a plain text
 format). You can then use the browser’s Save feature to save the project
-as an XML file, which should be named _`something`_`.xml` so that {.snap}`Snap`
-will recognize it as a project when you later drag it onto a {.snap}`Snap`
+as an XML file, which should be named _`something`_`.xml` so that [Snap!]{.snap}
+will recognize it as a project when you later drag it onto a [Snap!]{.snap}
 window. This is an alternative to saving the project to your cloud
 account: keeping it on your own computer. It is equivalent to choosing
 "`Computer`" from the Save dialog described earlier.
@@ -186,7 +186,7 @@ the global (for all sprites) blocks in your project, and lets you select
 which to export. It then opens a browser tab with those blocks in XML
 format, or stores directly to your local disk, as with the "`Export
 project`" option. Block libraries can be imported with the "`Import`" option
-or by dragging the file onto the {.snap}`Snap` window. This option is shown
+or by dragging the file onto the [Snap!]{.snap} window. This option is shown
 only if you have defined custom blocks.
 
 The "`Unused blocks…`" option\index{Unused blocks… option} presents a
@@ -199,7 +199,7 @@ The "`Hide blocks…`" option\index{Hide blocks… option} shows *all* blocks,
 including primitives, with checkboxes. This option does not remove any
 blocks from your project, but it does hide selected block in your
 palette. The purpose of the option is to allow teachers to present
-students with a simplified {.snap}`Snap` with some features effectively
+students with a simplified [Snap!]{.snap} with some features effectively
 removed. The hiddenness of primitives is saved with each project, so
 students can load a shared project and see just the desired blocks. But
 users can always unhide blocks by choosing this option and unclicking
@@ -217,7 +217,7 @@ easy-to-miss menu of category names just under the file icon in the menu
 bar. If you remove a category that has blocks in it, all those blocks
 are also removed.
 
-<!-- cut: , new in {.snap}`Snap` 7.0 -->
+<!-- cut: , new in [Snap!]{.snap} 7.0 -->
 The next group of options concern the *scenes*\index{scenes} feature. A scene
 is a complete project, with its own stage, sprites, and code, but
 several can be merged into one project, using the ![switch to scene block](assets/image999.png){ .image-4x .image-inline } <!--  style="width:1.16667in;height:0.19792in" / -->  block to bring another
@@ -276,7 +276,7 @@ You can import a single costume by clicking it and then clicking the
 Import button. Alternatively, you can import more than one costume by
 double-clicking each one, and then clicking Cancel when done. Notice
 that some costumes are tagged with “svg” in this picture; those are
-vector-format costumes that are not (yet) editable within {.snap}`Snap`.
+vector-format costumes that are not (yet) editable within [Snap!]{.snap}.
 
 If you have the stage selected in the sprite corral, rather than a
 sprite, the Costumes… option changes to a Backgrounds… option
@@ -306,19 +306,19 @@ costume).
 ### The Cloud Menu
 
  The cloud icon\index{cloud
-icon}  ![image1008.png](assets/image1008.png) <!--  style="width:0.29167in;height:0.16667in" / --> ![image1004.png](assets/image1004.png) <!--  style="width:0.29167in;height:0.16667in" / --> shows a menu of options relating to your {.snap}`Snap` cloud account. If
+icon}  ![image1008.png](assets/image1008.png) <!--  style="width:0.29167in;height:0.16667in" / --> ![image1004.png](assets/image1004.png) <!--  style="width:0.29167in;height:0.16667in" / --> shows a menu of options relating to your [Snap!]{.snap} cloud account. If
 you are not logged in, you see the outline icon  ![image1004.png](assets/image1004.png) <!--  style="width:0.29167in;height:0.16667in" / --> and get this menu:
 
 ![image1003.png](assets/image1003.png) <!--  style="width:1.43681in;height:0.75972in" / -->
 
-Choose Login…\index{Login… option} if you have a {.snap}`Snap` account and
+Choose Login…\index{Login… option} if you have a [Snap!]{.snap} account and
 remember your password. Choose Signup…\index{Signup… option} if you
 don’t have an account. Choose Reset Password…\index{Reset Password…
 option} if you’ve forgotten your password or just want to change it. You
 will then get an email, at the address you gave when you created your
 account, with a new temporary password. Use that password to log in,
 then you can choose your own password, as shown below. Choose Resend
-Verification Email… if you have just created a {.snap}`Snap` account but can’t
+Verification Email… if you have just created a [Snap!]{.snap} account but can’t
 find the email we sent you with the link to verify that it’s really your
 email. (If you still can’t find it, check your spam folder. If you are
 using a school email address, your school may block incoming email from
@@ -340,14 +340,14 @@ because it doesn’t echo. Open in Community Site is the same as above.
 ###  The Settings Menu
 
 The settings icon ![image1010.png](assets/image1010.png) <!--  style="width:0.29167in;height:0.16667in" / -->
-\index{settings icon} shows a menu of {.snap}`Snap` options, either for the
+\index{settings icon} shows a menu of [Snap!]{.snap} options, either for the
 current project or for you permanently, depending on the option:
 
 ![image1009.png](assets/image1009.png) <!--  style="width:1.24792in;height:2.58333in" / -->
 
-The Language… option\index{Language… option} lets you see the {.snap}`Snap`
+The Language… option\index{Language… option} lets you see the [Snap!]{.snap}
 user interface (blocks and messages) in a language other than English.
-(Note: Translations\index{translation} have been provided by {.snap}`Snap`
+(Note: Translations\index{translation} have been provided by [Snap!]{.snap}
 users. If your native language is missing, send us an email!)
 
 The Zoom blocks... option\index{Zoom blocks... option} lets you change
@@ -435,7 +435,7 @@ affects the picture by moving a slider.
 
 Turbo mode\index{Turbo mode option} makes many projects run much
 faster, at the cost of not keeping the stage display up to date.
-({.snap}`Snap` ordinarily spends most of its time drawing sprites and updating
+([Snap!]{.snap} ordinarily spends most of its time drawing sprites and updating
 variable watchers, rather than actually carrying out the instructions in
 your scripts.) So turbo mode isn’t a good idea for a project with glide
 block\index{glide block} s or one in which the user interacts with
@@ -452,7 +452,7 @@ equivalent to clicking the footprint button above the scripting area.
 You don’t want this on except when you’re actively debugging, because
 even the fastest setting of the slider is still slowed a lot.
 
-`Log pen vectors` tells {.snap}`Snap` to remember lines drawn by sprites as
+`Log pen vectors` tells [Snap!]{.snap} to remember lines drawn by sprites as
 exact vectors, rather than remember only the pixels that the drawing leaves on the stage. This
 remembered vector picture can be used in two ways: First, right-clicking
 on a `pen trails` block gives an option to relabel it into a pen vectors
@@ -469,7 +469,7 @@ created or edited, you immediately see the version of the input name
 dialog that includes the type options, default value setting, etc.,
 instead of the short form with just the name and the choice between
 input name and title text. The default (unchecked) setting is definitely
-best for beginners, but more experienced {.snap}`Snap` programmers may find it
+best for beginners, but more experienced [Snap!]{.snap} programmers may find it
 more convenient always to see the long form.
 
 Plain prototype labels\index{Plain prototype labels option} eliminates
@@ -485,23 +485,23 @@ sound effect whenever one block snaps next to another in a script.
 Certain very young children, and our colleague Dan Garcia, like this,
 but if you are such a child you should bear in mind that driving your
 parents or teachers crazy will result in you not being allowed to use
-{.snap}`Snap`. It might, however, be useful for visually impaired users.
+[Snap!]{.snap}. It might, however, be useful for visually impaired users.
 
-Flat design\index{Flat design option} changes the “skin” of the {.snap}`Snap`
+Flat design\index{Flat design option} changes the “skin” of the [Snap!]{.snap}
 window to a really hideous design with white and pale-grey background,
 rectangular rather than rounded buttons, and monochrome blocks (rather
 than the shaded, somewhat 3D-looking normal blocks). The monochrome
 blocks are the reason for the “flat” in the name of this option. The
 only thing to be said for this option is that, because of the white
 background, it may blend in better with the rest of a web page when a
-{.snap}`Snap` project is run in a frame in a larger page. (I confess I used it
+[Snap!]{.snap} project is run in a frame in a larger page. (I confess I used it
 to make the picture of blocks faded all the way to just text two pages
 ago, though.)
 
-The final group of settings change the way {.snap}`Snap` interprets your
+The final group of settings change the way [Snap!]{.snap} interprets your
 program; they are saved with the project, so anyone who runs your
 project will experience the same behavior. Thread safe scripts
-\index{Thread safe scripts option} changes the way {.snap}`Snap` responds when
+\index{Thread safe scripts option} changes the way [Snap!]{.snap} responds when
 an event (clicking the green flag, say) starts a script, and then, while
 the script is still running, the same event happens again. Ordinarily,
 the running process stops where it is, ignoring the remaining commands
@@ -526,7 +526,7 @@ best when turning corners. With this option selected, the ends are flat.
 It’s useful for drawing a brick wall or a filled rectangle.
 
 Codification support\index{codification support option} enables a
-feature that can translate a {.snap}`Snap` project to a text-based
+feature that can translate a [Snap!]{.snap} project to a text-based
 \index{text-based language} (rather than block-based) programming
 language. The feature doesn’t know about any particular other language;
 instead, you can provide a translation for each primitive block using
@@ -567,7 +567,7 @@ saturation, and brightness (a/k/a value). Note: the name “saturation”
 means something different in HSL from in HSV! See Appendix A for all the
 information you need about colors.\index{pen block}
 
-The Disable click-to-run option tells {.snap}`Snap` to ignore user mouse
+The Disable click-to-run option tells [Snap!]{.snap} to ignore user mouse
 clicks on blocks and scripts if it would ordinarily run the block or
 script. (Right-clicking and dragging still work, and so does clicking in
 an input slot to edit it.) This is another Parsons problem feature; the
@@ -675,7 +675,7 @@ palette (color) preselected.
 ### Context Menus for Palette Blocks {#sec-context-menus-for-palette-blocks}
 
  Most elements\index{context
-menus for palette blocks} of the {.snap}`Snap` display can be
+menus for palette blocks} of the [Snap!]{.snap} display can be
 control-clicked/right-clicked to show a *context menu*\index{context
 menu} *,* with items relevant to that element. If you
 control-click/right-click a *primitive* block in the palette, you see
@@ -759,7 +759,7 @@ built-in categories in the category selector:
 ![image1060.png](assets/image1060.png) <!--  style="width:1.42986in;height:2.90972in" alt="Graphical user interface, application Description automatically generated" / -->
 
 This
-example comes {index}`from Eckart<single: Eckart, from>` Modrow’s Sci{.snap}`Snap`
+example comes {index}`from Eckart<single: Eckart, from>` Modrow’s [SciSnap!]{.snap}
 \index{"SciSnap!"} library. Note that the custom category list has its own
 scroll bar, which appears if you have more than six custom categories.
 Note also that the buttons to select a custom category occupy the full
@@ -790,7 +790,7 @@ of the palette below its standard value.
 ## The Scripting Area
 
 The {index}`scripting area` is the middle vertical region
-of the {.snap}`Snap` window, containing scripts and also some controls for the
+of the [Snap!]{.snap} window, containing scripts and also some controls for the
 appearance and behavior of a sprite. There is always a *current sprite*
 \index{current sprite} *,* whose scripts are shown in the scripting
 area. A dark grey rounded rectangle in the sprite corral shows which
@@ -855,7 +855,7 @@ it’s running. If the script is shared with clones, then while it has the
 green halo it will also have a count of how many instances of the script
 are running. Clicking a script with such a halo\index{halo} *stops* the
 script. (If the script includes a {index}`warp block`, which
-might be inside a custom block used in the script, then {.snap}`Snap` may not
+might be inside a custom block used in the script, then [Snap!]{.snap} may not
 respond immediately to clicks.)
 
 If a script is shown with a
@@ -906,7 +906,7 @@ feature to access them.
 Not every reporter has a compile option\index{compile menu option}; it
 exists only for the higher order functions. When selected, a lightning
 bolt\index{lightning bolt symbol} appears before the block name:
-![image1072.png](assets/image1072.png) <!--  style="width:1.40278in;height:0.20139in" alt="Macintosh HD:Users:bh:Desktop:lightning.png" / -->  and {.snap}`Snap` tries
+![image1072.png](assets/image1072.png) <!--  style="width:1.40278in;height:0.20139in" alt="Macintosh HD:Users:bh:Desktop:lightning.png" / -->  and [Snap!]{.snap} tries
 to compile the function inside the ring to JavaScript, so it runs at
 primitive speed. This works only for simple functions (but the higher
 order function still works even if the compilation doesn’t). The
@@ -951,7 +951,7 @@ entire script\index{picture of script}, not just from the selected
 block to the end, into your download folder; or, in some browsers, opens
 a new browser tab containing the picture. In the latter case, you can
 use the browser’s Save feature to put the picture in a file. This is a
-super useful feature if you happen to be writing a {.snap}`Snap` manual
+super useful feature if you happen to be writing a [Snap!]{.snap} manual
 \index{Snap! manual} ! (If you have a Retina display, consider turning
 off Retina support before making script pictures; if not, they end up
 huge.) For reporters not inside a script, there is an additional result
@@ -1082,7 +1082,7 @@ something like this:
 
 The Turtle costume
 \index{turtle costume} is always present in every sprite; it is costume
-number 0. Other costumes can be painted within {.snap}`Snap` or imported from
+number 0. Other costumes can be painted within [Snap!]{.snap} or imported from
 files or other browser tabs if your browser supports that. Clicking on a
 costume selects it; that is, the sprite will look like the selected
 costume. Clicking on the paint brush icon ![image1084.png](assets/image1084.png) <!--  style="width:0.29167in;height:0.16667in" / -->\index{paint brush icon}
@@ -1091,8 +1091,8 @@ create a new costume. Clicking on the camera icon ![image1083.png](assets/image1
 opens a window in which you see what your computer’s camera is seeing,
 and you can take a picture (which will be the full size of the stage
 unless you shrink it in the Paint Editor). This works only if you give
-{.snap}`Snap` permission to use the camera, and maybe only if you opened
-{.snap}`Snap` in secure (HTTPS\index{HTTPS} ) mode, and then only if your
+[Snap!]{.snap} permission to use the camera, and maybe only if you opened
+[Snap!]{.snap} in secure (HTTPS\index{HTTPS} ) mode, and then only if your
 browser loves you.
 
 ![image1085.png](assets/image1085.png) <!--  style="width:3.56944in;height:3.18056in" alt="Macintosh HD:Users:bh:Desktop:pix:camera-dialog.png" / -->
@@ -1202,7 +1202,7 @@ Note that the {index}`ellipse tool` s work more intuitively
 than ones in other software you may have used. Instead of dragging
 between opposite corners of the rectangle circumscribing the ellipse you
 want, so that the endpoints of your dragging have no obvious connection
-to the actual shape, in {.snap}`Snap` you start at the center of the ellipse
+to the actual shape, in [Snap!]{.snap} you start at the center of the ellipse
 you want and drag out to the edge. When you let go of the button, the
 mouse cursor will be on the curve. If you drag out from the center at 45
 degrees to the axes, the resulting curve will be a circle; if you drag
@@ -1213,7 +1213,7 @@ expect: You start at one corner of the desired rectangle and drag to the
 opposite corner.
 
 Using the {index}`eyedropper tool`, you can click
-anywhere in the {.snap}`Snap` window, even outside the Paint Editor, and the
+anywhere in the [Snap!]{.snap} window, even outside the Paint Editor, and the
 tool will select the color at the mouse cursor for use in the Paint
 Editor. You can only do this once, because the Paint Editor
 automatically selects the paintbrush when you choose a color. (Of course
@@ -1248,7 +1248,7 @@ shapes within that area.
 ### Controls in the Sounds Tab
 
 There is no
-Sound Editor\index{controls in the Sounds tab} in {.snap}`Snap`, and also no
+Sound Editor\index{controls in the Sounds tab} in [Snap!]{.snap}, and also no
 current sound the way there’s a current costume for each sprite. (The
 sprite always has an appearance unless hidden, but it doesn’t sing
 unless explicitly asked.) So the context menu for sounds has only
@@ -1412,7 +1412,7 @@ to run the script with the editor focus, like clicking the script.
 
 ## Controls on the Stage\index{controls on the stage}
 
-The stage is the area in the top right of the {.snap}`Snap` window in which
+The stage is the area in the top right of the [Snap!]{.snap} window in which
 sprites move.
 
 ### Sprites
@@ -1524,7 +1524,7 @@ and/or text; lists of blocks, sprites, costumes, etc. cannot be
 exported.)
 
 An alternative to using the import… option is simply to drag the file
-onto the {.snap}`Snap` window, in which case a variable will be created if
+onto the [Snap!]{.snap} window, in which case a variable will be created if
 necessary with the same name as the file (but without the extension).
 
 If the value of the variable is a list, then the menu will include an
@@ -1570,7 +1570,7 @@ lines are logged, not color regions made with the fill block.
 ## The {index}`Sprite Corral`  and Sprite Creation Buttons\index{sprite creation buttons}
 
 Between the stage and the
-sprite corral at the bottom right of the {.snap}`Snap` window is a dark grey
+sprite corral at the bottom right of the [Snap!]{.snap} window is a dark grey
 bar containing three buttons at the left and one at the right. The first
 three are used to create a new sprite. The first button  ![image1124.png](assets/image1124.png) <!--  style="width:0.29167in;height:0.16667in" / -->  makes a sprite
 with just the turtle costume, with a randomly chosen position and pen
@@ -1630,12 +1630,12 @@ Clicking on a
 scene will select it; right-clicking will present a menu in which you
 can rename, delete, or export the scene.
 
-## Preloading a Project\index{preloading a project}  when Starting {.snap}`Snap`
+## Preloading a Project\index{preloading a project}  when Starting [Snap!]{.snap}
 
 There are several ways to include a pointer to a project in the URL when
-starting {.snap}`Snap`\index{"starting Snap!"} in order to load a project
+starting [Snap!]{.snap}\index{"starting Snap!"} in order to load a project
 automatically. You can think of such a URL as just running the project
-rather than as running {.snap}`Snap`, especially if the URL says to start in
+rather than as running [Snap!]{.snap}, especially if the URL says to start in
 presentation mode and click the green flag. The general form is
 
 https://snap.berkeley.edu/run#***verb***:***project***&***flag***&***flag***…
@@ -1643,16 +1643,16 @@ https://snap.berkeley.edu/run#***verb***:***project***&***flag***&***flag***…
 The “verb” above can be any of open\index{open (startup option)}, run
 \index{run (startup option)}, cloud\index{cloud (startup option)},
 present\index{present (startup option)}, or dl\index{dl (startup
-option)} . The last three are for shared projects in the {.snap}`Snap` cloud;
+option)} . The last three are for shared projects in the [Snap!]{.snap} cloud;
 the first two are for projects that have been exported and made
 available anywhere on the Internet.
 
-Here’s an example that loads a project stored at the {.snap}`Snap` web site
-(not the {.snap}`Snap` cloud!):
+Here’s an example that loads a project stored at the [Snap!]{.snap} web site
+(not the [Snap!]{.snap} cloud!):
 
 https://snap.berkeley.edu/run#open:https://snap.berkeley.edu/snapsource/Examples/vee.xml
 
-The project file will be opened, and {.snap}`Snap` will start in edit mode
+The project file will be opened, and [Snap!]{.snap} will start in edit mode
 (with the program visible). Using \#run: instead of \#open: will start
 in presentation mode (with only the stage visible) and will “start” the
 project by clicking the green flag. (“Start” is in quotation marks
@@ -1683,9 +1683,9 @@ window or loading a different URL, don’t show the browser “are you sure you 
 - &blocksZoom=n : Like the Zoom blocks option in the Settings menu.
 
 The last of these flags is intended for use on a web page in which a
-{.snap}`Snap` window is embedded.
+[Snap!]{.snap} window is embedded.
 
-Here’s an example that loads a shared (public) project from the {.snap}`Snap`
+Here’s an example that loads a shared (public) project from the [Snap!]{.snap}
 cloud:
 
 https://snap.berkeley.edu/run#present:Username=jens&ProjectName=tree%20animation
@@ -1696,16 +1696,16 @@ project name must be represented in Unicode as %20.) The verb present
 behaves like run: it ordinarily starts the project in presentation mode,
 but its behavior can be modified with the same four flags as for run.
 The verb cloud (yes, we know it’s not a verb in its ordinary use)
-behaves like open except that it loads from the {.snap}`Snap` cloud rather
+behaves like open except that it loads from the [Snap!]{.snap} cloud rather
 than from the Internet in general. The verb dl (short for “download”)
-does not start {.snap}`Snap` but just downloads a cloud-saved project to your
+does not start [Snap!]{.snap} but just downloads a cloud-saved project to your
 computer as an .xml file. This is useful for debugging; sometimes a
-defective project that {.snap}`Snap` won’t run can be downloaded, edited, and
+defective project that [Snap!]{.snap} won’t run can be downloaded, edited, and
 then re-saved to the cloud.
 
 ## Mirror Sites
 
-If the site snap.berkeley.edu is ever unavailable, you can load {.snap}`Snap`
+If the site snap.berkeley.edu is ever unavailable, you can load [Snap!]{.snap}
 at the following {index}`mirror sites` :
 
 - https://bjc.edc.org\index{bjc.edc.org} /snapsource/snap.html

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -6,7 +6,19 @@
 * Write UI elements inside quoted code blocks. e.g. ```"`Open`"```
 * Monospaced text should use the CSS class `.mono` e.g. `[text here]{.mono}`
 * Do not put spaces around index entries. `text\index{text},`
-* To write Snap! as stylized text write: `{.snap}`Snap``
+* To write Snap! as stylized text, use `[Snap!]{.snap}`. This works in body
+  text, headings, and other inline contexts. The `_support/scripts/replace-snap.lua`
+  filter rewrites it to the right markup for HTML and LaTeX, so the trailing
+  `!` renders in italics in both formats and is included in the actual heading
+  text (so it appears in the sidebar, the TOC, the page `<title>`, and search).
+  * For compound names like SciSnap! use `[SciSnap!]{.snap}`.
+  * The legacy `` {.snap}`Snap` `` syntax is still accepted by the filter, but
+    new content should use the bracketed-span form.
+  * In raw YAML metadata that doesn't go through Pandoc filtering (for
+    example, format-specific titles in `_quarto.yml`), use the per-format
+    markup directly: `<span class="snap">Snap<em>!</em></span>` for HTML,
+    `Snap\textit{!}` for LaTeX. Plain `Snap!` is fine for `description`,
+    `alt` text, and other text-only fields.
 * Chapters are included at the top level of the repo, named 'NN-chapter'
   * Each contains an `index.md` file, which is the chapter's main content.
   * The `assets/` folder contains images used in the chapter.

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -50,6 +50,7 @@ format:
     aria: true # requires quarto-dev / v1.8+
     toc: true
     filters:
+      - _support/scripts/replace-snap.lua
       - _support/scripts/collect-index.lua
       - _support/scripts/exclude-blocks-toc.lua
     link-external-icon: true
@@ -150,7 +151,11 @@ format:
 #   center: center-env
 
 book:
-  title: Snap<em>!</em> Reference Manual
+  # The `[Snap!]{.snap}` span is rewritten by replace-snap.lua to the right
+  # markup for each format (a styled span for HTML, `Snap\textit{!}` for
+  # LaTeX). The PDF format above also has a raw-LaTeX `title:` override that
+  # takes effect for that one format.
+  title: "[Snap!]{.snap} Reference Manual"
   output-file: snap-manual
   author: Brian Harvey, Jens Mönig, Michael Ball, Jadga Hügle, Victoria Phelps, Bernat Romagosa
   date: September 1, 2025

--- a/_support/scripts/replace-snap.lua
+++ b/_support/scripts/replace-snap.lua
@@ -1,13 +1,74 @@
-function Span(elem)
-  if elem.classes:includes('snap') and #elem.content == 1 then
-    local str = elem.content[1]
-    if str.t == 'Str' and str.text == 'Snap' then
-      return pandoc.RawInline('latex', 'Snap\\textit{!}')
-    end
+-- Stylize "Snap!" (and friends like "SciSnap!") consistently across formats.
+--
+-- Source convention (preferred): `[Snap!]{.snap}` (a Pandoc inline span).
+-- Legacy convention (still supported): `` {.snap}`Snap` `` (an inline code span).
+--
+-- The filter normalizes any `Span` or `Code` element with the `.snap` class so
+-- that the trailing "!" is rendered in italics, while the leading text (e.g.
+-- "Snap", "SciSnap") is emitted as-is. The actual character "!" is kept in the
+-- document text — not added via CSS `::after` — so that headings, the sidebar,
+-- the TOC, the page `<title>`, and search all see "Snap!".
+
+local function is_emph_bang(elem)
+  if elem.t ~= 'Emph' then return false end
+  if #elem.content ~= 1 then return false end
+  local inner = elem.content[1]
+  return inner.t == 'Str' and inner.text == '!'
+end
+
+local function strip_trailing_bang(inlines)
+  local n = #inlines
+  if n == 0 then return inlines end
+  local last = inlines[n]
+  -- Already in canonical form: ends with Emph("!"). Strip so we can re-add it.
+  if is_emph_bang(last) then
+    inlines:remove(n)
+    return inlines
   end
+  if last.t ~= 'Str' then return inlines end
+  local text = last.text
+  if text:sub(-1) ~= '!' then return inlines end
+  if #text == 1 then
+    inlines:remove(n)
+  else
+    inlines[n] = pandoc.Str(text:sub(1, -2))
+  end
+  return inlines
+end
+
+local function render_snap(inlines)
+  inlines = strip_trailing_bang(inlines)
+  if FORMAT:match('latex') then
+    local prefix = pandoc.utils.stringify(inlines)
+    return pandoc.RawInline('latex', prefix .. '\\textit{!}')
+  end
+  inlines:insert(pandoc.Emph(pandoc.Inlines({ pandoc.Str('!') })))
+  return inlines
+end
+
+function Span(elem)
+  if not elem.classes:includes('snap') then return nil end
+  local rendered = render_snap(elem.content)
+  if FORMAT:match('latex') then
+    return rendered
+  end
+  elem.content = rendered
+  return elem
+end
+
+function Code(elem)
+  if not elem.classes:includes('snap') then return nil end
+  local content = pandoc.Inlines({ pandoc.Str(elem.text) })
+  local rendered = render_snap(content)
+  if FORMAT:match('latex') then
+    return rendered
+  end
+  return pandoc.Span(rendered, pandoc.Attr('', { 'snap' }))
 end
 
 function Image(img)
+  -- The image-2x class is styled via CSS in HTML; only rewrite it for LaTeX.
+  if not FORMAT:match('latex') then return nil end
   if img.classes:includes('image-2x') then
     for i, class in ipairs(img.classes) do
       if class == 'image-2x' then

--- a/_support/styles/snap-manual.scss
+++ b/_support/styles/snap-manual.scss
@@ -180,16 +180,22 @@ p code:not(.sourceCode) {
 // TODO: make latex command
 // This is the font used in the Word document.`
 // TODO: load Candara font.
+//
+// The trailing "!" is wrapped in an <em> so it lives in the actual document
+// text (sidebar/TOC/<title>/search all see "Snap!"). The lua filter
+// `_support/scripts/replace-snap.lua` produces this markup from
+// `[Snap!]{.snap}` for both HTML and LaTeX output.
 .snap {
   font-size: 1.1em;
   font-family: "candara", sans-serif;
   font-weight: 400;
   font-style: normal;
-}
 
-.snap::after {
-  content: '!';
-  font-style: italic;
+  em {
+    font-family: inherit;
+    font-weight: inherit;
+    font-style: italic;
+  }
 }
 
 // TODO: Style paragraph indents?

--- a/appendix/a-snap-color-library/index.md
+++ b/appendix/a-snap-color-library/index.md
@@ -1,4 +1,4 @@
-# Appendix A. {.snap}`Snap` color library {#sec-appendix-a-colors}
+# Appendix A. [Snap!]{.snap} color library {#sec-appendix-a-colors}
 
 The Colors and Crayons library\index{Colors and Crayons library}
 provides several tools for manipulating color. Although its main purpose
@@ -99,7 +99,7 @@ has to be rounded to integer RGB values for display.)
 
 Both of these scales include the range of shades of gray\index{gray},
 from black to white. Since black is the initial pen color, and black
-isn’t a hue, Scratch and {.snap}`Snap` users would traditionally try to use
+isn’t a hue, Scratch and [Snap!]{.snap} users would traditionally try to use
 set color to escape from black, and it wouldn’t work. By including black
 in the same scale as other colors, we eliminate the Black Hole problem
 \index{Black Hole problem} if people use only the recommended color
@@ -354,7 +354,7 @@ means all white, no spectral color; a saturation of 100 means no white
 at all. In the square in the previous paragraph, the *x* axis is the
 saturation and the *y* axis is the value. The entire bottom edge is
 black, but only the top left corner is white. HSV is the traditional
-color space used in Scratch and Snap*!.* Set pen color set the hue; set
+color space used in Scratch and [Snap!]{.snap}. Set pen color set the hue; set
 pen shade set the value. There was originally no Pen block to set the
 saturation, but there’s a set brightness effect Looks block to control
 the saturation of the sprite’s costume. (I speculate that the Scratch
@@ -410,7 +410,7 @@ more coherent than jumping around Wikipedia if you’re interested.
 ![image1204.png](assets/image1204.png) <!--  style="width:1.64375in;height:0.84167in" / -->
 
 Although traditional Scratch
-and {.snap}`Snap` use HSV in programs, they use HSL in the color picker
+and [Snap!]{.snap} use HSV in programs, they use HSL in the color picker
 \index{color picker}. The horizontal axis is hue (fair hue\index{fair
 hue} , in this version) and the vertical axis is *lightness,* the scale
 with black at one end and white at the other end. It would make no sense
@@ -543,7 +543,7 @@ mistakes are bh’s.)
 
 ### tl;dr {#sec-tldr-spirals}
 
-For {index}`normal people`, {.snap}`Snap` provides three simple,
+For {index}`normal people`, [Snap!]{.snap} provides three simple,
 one-dimensional scales: *<u>crayons</u>* for specific interesting
 colors, *<u>color numbers</u>* for a continuum of high-contrast colors
 with a range of hues and shading, and *<u>fair hues</u>* for a continuum
@@ -702,4 +702,4 @@ five, except for item 4, which is used for color 14, not color 15:
 The very pale three-input list blocks are for color numbers that are odd
 multiples of five, generally the “darkest” members of each color family.
 (The block colors were adjusted in Photoshop; don’t ask how to get
-blocks this color in {.snap}`Snap`.)
+blocks this color in [Snap!]{.snap}.)

--- a/appendix/b-apl-features/index.md
+++ b/appendix/b-apl-features/index.md
@@ -28,21 +28,21 @@ function} , {index}`mixed functions`, and operators
 \index{operator (APL)}. A *scalar function* is one whose natural domain
 is individual numbers or text characters. A *mixed function* is one
 whose domain includes arrays (vectors, matrices, or higher-dimensional
-collections). In {.snap}`Snap`, scalar functions are generally found in the
+collections). In [Snap!]{.snap}, scalar functions are generally found in the
 green Operators palette, while mixed functions are in the red Lists
-palette. The third category, confusingly for {.snap}`Snap` users, is called
+palette. The third category, confusingly for [Snap!]{.snap} users, is called
 *operators* in APL, but corresponds to what we call higher order
 functions\index{function, higher order} : functions whose domain
 includes functions.
 
-{.snap}`Snap` hyperblocks\index{hyperblocks} are scalar functions that behave
+[Snap!]{.snap} hyperblocks\index{hyperblocks} are scalar functions that behave
 like APL scalar functions: they can be called with arrays as inputs, and
 the underlying function is applied to each number in the arrays. (If the
 function is *monadic,* meaning that it takes one input, then there’s no
 complexity to this idea. Take the square root of an array, and you are
 taking the square root of each number in the array. If the function is
 *dyadic,* taking two inputs, then the two arrays must have the same
-shape. {.snap}`Snap` is more forgiving than APL; if the arrays don’t agree in
+shape. [Snap!]{.snap} is more forgiving than APL; if the arrays don’t agree in
 number of dimensions, called the *rank* of the array, the lower-rank
 \index{rank} array is matched repeatedly with subsets of the higher-rank
 one; if they don’t agree in length along one dimension, the result has
@@ -53,7 +53,7 @@ array input.)
 
 As explained in Section IV.F, this termwise extension\index{termwise
 extension} of scalar functions is the main APL-like feature built into
-{.snap}`Snap` itself. We also include an extension of the item block
+[Snap!]{.snap} itself. We also include an extension of the item block
 \index{item block} to address multiple dimensions, an extension to the
 {index}`length block` with five list functions from APL, and
 a new primitive {index}`reshape block`. The APL library
@@ -62,7 +62,7 @@ include a few missing scalar functions and several missing mixed
 functions and operators.
 
 Programming in APL really is *very* different in style from programming
-in other languages, even {.snap}`Snap`. This appendix can’t hope to be a
+in other languages, even [Snap!]{.snap}. This appendix can’t hope to be a
 complete reference for APL, let alone a tutorial. If you’re interested,
 find one of those in a library or a (probably used) bookstore, read it,
 and *do the exercises.* Sorry to sound like a teacher, but the notation
@@ -81,22 +81,22 @@ before you could download fonts in software. Today the more unusual APL
 characters\index{APL character set} are in Unicode\index{Unicode} at
 U+2336 to U+2395.) The character set was probably the main reason APL
 didn’t take over the world. APL2\index{APL2} has a lot to recommend it
-for {.snap}`Snap` users, mainly because it moves from the original APL idea
+for [Snap!]{.snap} users, mainly because it moves from the original APL idea
 that all arrays must be uniform in dimension, and the elements of arrays
 must be numbers or single text characters, to our idea that a list can
 be an element of another list, and that such elements don’t all have to
 have the same dimensions. Nevertheless, its mechanism for allowing both
 old-style APL arrays and more general “nested arrays” is complicated and
-hard for an APL beginner (probably all but two or three {.snap}`Snap` users)
+hard for an APL beginner (probably all but two or three [Snap!]{.snap} users)
 to understand. So we are starting with plain APL. If it turns out to be
 wildly popular, we may decide later to include APL2 features.
 
 Here are some of the guiding ideas in the design of the APL library:
 
 - Goal:  Enable interested
-**{.snap}`Snap`** users to learn the feel and style of APL programming. It’s
+**[Snap!]{.snap}** users to learn the feel and style of APL programming. It’s
 really worth the effort. For example, we didn’t hyperize the = block
-because {.snap}`Snap` users expect it to give a single yes-or-no answer about
+because [Snap!]{.snap} users expect it to give a single yes-or-no answer about
 the equality of two complete structures\index{equality of complete
 structures} , whatever their types and shapes. In APL, = is a scalar
 function; it compares two numbers or two characters. How could APL users
@@ -106,11 +106,11 @@ left, a=b reports an array of Booleans (represented in APL as 0 for
 False, 1 for True); the comma operator turns the shape of the array into
 a simple vector; and **∧**/ means “reduce with and”; “reduce” is our
 combine function. That six-character program is much less effort than
-the equivalent ![image1263.png](assets/image1263.png) <!--  style="width:4.45139in;height:0.52083in" / --> in {.snap}`Snap`. Note in passing
+the equivalent ![image1263.png](assets/image1263.png) <!--  style="width:4.45139in;height:0.52083in" / --> in [Snap!]{.snap}. Note in passing
 that if you wanted to know *how many* corresponding elements of the two
 arrays are equal, you’d just use +/ instead of **∧**/. Note also that
 our APLish blocks are a little verbose, because they include up to three
-notations for the function: the usual {.snap}`Snap` name (e.g., flatten), the
+notations for the function: the usual [Snap!]{.snap} name (e.g., flatten), the
 name APL programmers use when talking about it (ravel\index{ravel
 block} ), and, in yellow type, the symbol used in actual APL code (,).
 We’re not consistent about it; ![image1264.png](assets/image1264.png) <!--  style="width:0.99306in;height:0.20833in" / -->  seems self-documenting. And LCM (and) is
@@ -118,19 +118,19 @@ different even though it has two names; it turns out that if you
 represent Boolean values as 0 and 1, then the algorithm to compute the
 least common multiple of two integers computes the and function if the
 two inputs happen to be Boolean. Including the APL symbols serves two
-purposes: the two or three {.snap}`Snap` users who’ve actually programmed in
+purposes: the two or three [Snap!]{.snap} users who’ve actually programmed in
 APL will be sure what function they’re using, but more importantly, the
-ones who are reading an APL tutorial while building programs in {.snap}`Snap`
+ones who are reading an APL tutorial while building programs in [Snap!]{.snap}
 will find the block that matches the APL they’re reading.
 
 - Goal:  Bring the best and most general APL ideas into “mainstream”
-**{.snap}`Snap`** programming style. Media computation\index{media
+**[Snap!]{.snap}** programming style. Media computation\index{media
 computation} , in particular, becomes much simpler when scalar functions
 can be applied to an entire picture or sound. Yes, map provides
 essentially the same capability, but the notation gets complicated if
-you want to map over columns rather than rows. Also, {.snap}`Snap` lists are
+you want to map over columns rather than rows. Also, [Snap!]{.snap} lists are
 fundamentally one-dimensional, but real data often have more dimensions.
-A {.snap}`Snap` programmer has to be thinking all the time about the
+A [Snap!]{.snap} programmer has to be thinking all the time about the
 convention that we represent a matrix as a list of rows, each of which
 is a list of individual cells. That is, row 23 of a spreadsheet
 \index{spreadsheet} is item 23 of spreadsheet, but column 23 is map
@@ -138,7 +138,7 @@ is a list of individual cells. That is, row 23 of a spreadsheet
 symmetrically.
 
 - Non-goal:  Allow programs written originally in APL to run in
-**{.snap}`Snap`** essentially unchanged.  For example, in APL the atomic text
+**[Snap!]{.snap}** essentially unchanged.  For example, in APL the atomic text
 unit is a single character, and strings of characters are lists. We
 treat a text string as scalar, and that isn’t going to change. Because
 APL programmers rarely use conditionals, instead computing functions
@@ -166,7 +166,7 @@ seven, not six plus four. That takes some getting used to, but it really
 doesn’t take long if you immerse yourself in APL. The reason is that
 there are too many infix operators for people to memorize a precedence
 table. But in any case, block notation eliminates the problem,
-especially with {.snap}`Snap`’s zebra coloring. You can see and control the
+especially with [Snap!]{.snap}’s zebra coloring. You can see and control the
 grouping by which block is inside which other block’s input slot.
 Another problem with APL’s syntax is that it bends over backward not to
 have reserved words, as opposed to Fortran, its main competition back
@@ -177,12 +177,12 @@ asked; it’s$\\\sqrt{1 - x^{2}}$.
 
 ## Boolean values
 
-{.snap}`Snap` uses distinct Boolean values true and false that are different
+[Snap!]{.snap} uses distinct Boolean values true and false that are different
 from other data types. APL uses 1 and 0, respectively. The APL style of
 programming depends heavily on doing arithmetic on Booleans, although
 their conditionals insist on only 0 or 1 in a Boolean input slot, not
-other numbers. {.snap}`Snap` *arithmetic* functions treat false as 0 and true
-as 1, so our APL library tries to report {.snap}`Snap` Boolean values from
+other numbers. [Snap!]{.snap} *arithmetic* functions treat false as 0 and true
+as 1, so our APL library tries to report [Snap!]{.snap} Boolean values from
 predicate functions.
 
 ### Scalar functions
@@ -301,7 +301,7 @@ hyperblock, applying itself to each item of its input list:
 block} has a special meaning for list inputs: The input must be a shape
 vector; the result is an array with that shape in which each item is a
 list of the indices of the cell along each dimension. A picture is worth
-10<sup>3</sup> words, but {.snap}`Snap` isn’t so good at displaying arrays
+10<sup>3</sup> words, but [Snap!]{.snap} isn’t so good at displaying arrays
 with more than two dimensions, so here we reduce each cell’s index list
 to a string:
 
@@ -520,7 +520,7 @@ adding individual numbers, it’s clear that in
 
  the *vector*
 (10, 26, 42) is the sum of *column vectors* (1, 5, 9)+(2, 6, 10)+(3, 7,
-11)+(4, 8, 12). In pre-6.0 {.snap}`Snap`, we’d get the same result this way:
+11)+(4, 8, 12). In pre-6.0 [Snap!]{.snap}, we’d get the same result this way:
 
 ![image1334.png](assets/image1334.png) <!--  style="width:4.80833in;height:1.1in" alt="Macintosh HD:Users:bh:Desktop:non-apl-combine.png" / -->
 
@@ -556,7 +556,7 @@ have corresponding items in common.
 
 ![image1339.png](assets/image1339.png) <!--  style="width:0.95833in;height:0.18333in" alt="Macintosh HD:Users:bh:Desktop:printable.png" / --> The printable block
 \index{printable block} isn’t an APL function; it’s an aid to exploring
-APL-in-{.snap}`Snap`. It transforms arrays to a compact representation that
+APL-in-[Snap!]{.snap}. It transforms arrays to a compact representation that
 still makes the structure clear:
 
 ![image1340.png](assets/image1340.png) <!--  style="width:5.99792in;height:0.33333in" alt="Macintosh HD:Users:bh:Desktop:printable-ex.png" / -->

--- a/appendix/community/index.md
+++ b/appendix/community/index.md
@@ -1,6 +1,6 @@
-# The Snap<em>!</em> Community Site {.unnumbered}
+# The [Snap!]{.snap} Community Site {.unnumbered}
 
-The {.snap}`Snap` [community website]{#sec-appendix-community} is what you see when you visit [https://snap.berkeley.edu](https://snap.berkeley.edu). {#sec-appendix-community}
+The [Snap!]{.snap} [community website]{#sec-appendix-community} is what you see when you visit [https://snap.berkeley.edu](https://snap.berkeley.edu). {#sec-appendix-community}
 
 ## User Accounts {.unnumbered .unlisted}
 

--- a/appendix/community/teachers.md
+++ b/appendix/community/teachers.md
@@ -1,6 +1,6 @@
 # Teacher Accounts {.unnumbered .unlisted}
 
-Snap<em>!</em> supports basic teacher account functionality.
+[Snap!]{.snap} supports basic teacher account functionality.
 
 ## Bulk Account Creation {.unnumbered .unlisted}
 

--- a/appendix/libraries/index.md
+++ b/appendix/libraries/index.md
@@ -1,1 +1,1 @@
-# Libraries in {.snap}`Snap` {#sec-libraries}
+# Libraries in [Snap!]{.snap} {#sec-libraries}

--- a/blocks/_block.md
+++ b/blocks/_block.md
@@ -46,4 +46,4 @@ No examples yet.
 
 ---
 
-_Individual pages for each block are new. Most blocks don't yet additional links and images. If you have any questions, please post in the {.snap}`Snap` [forum](https://forum.snap.berkeley.edu/c/help/snap-help/49)._
+_Individual pages for each block are new. Most blocks don't yet additional links and images. If you have any questions, please post in the [Snap!]{.snap} [forum](https://forum.snap.berkeley.edu/c/help/snap-help/49)._

--- a/blocks/index.md
+++ b/blocks/index.md
@@ -2,7 +2,7 @@
 page-layout: full
 ---
 
-# All Snap<em>!</em> Blocks {.unnumbered}
+# All [Snap!]{.snap} Blocks {.unnumbered}
 
 <!--
 The table below is currently generated from

--- a/blocks/render-block.py
+++ b/blocks/render-block.py
@@ -67,7 +67,7 @@ def render_block_markdown(yaml_data):
     # Footer
     markdown_content.append("---")
     markdown_content.append("")
-    markdown_content.append("_Individual pages for each block are new. Most blocks don't yet additional links and images. If you have any questions, please post in the {.snap}`Snap` [forum](https://forum.snap.berkeley.edu/c/help/snap-help/49)._")
+    markdown_content.append("_Individual pages for each block are new. Most blocks don't yet additional links and images. If you have any questions, please post in the [Snap!]{.snap} [forum](https://forum.snap.berkeley.edu/c/help/snap-help/49)._")
 
     return "\n".join(markdown_content)
 

--- a/index.md
+++ b/index.md
@@ -1,4 +1,4 @@
-# The {.snap}`snap` Reference Manual
+# The [Snap!]{.snap} Reference Manual
 
 <!--
   This is the first page of the Snap! Manual.
@@ -10,7 +10,7 @@
 ::: {.callout-note}
 ## This a work in progress!
 
-Welcome to the "new" {.snap}`Snap` manual. However, there are still many images and pages that need proper formatting and updates for version 11.
+Welcome to the "new" [Snap!]{.snap} manual. However, there are still many images and pages that need proper formatting and updates for version 11.
 
 You may wish to [read a very nicely typeset version][pdf] of the manual.
 
@@ -19,7 +19,7 @@ You may wish to [read a very nicely typeset version][pdf] of the manual.
 
 **Version 11.0**
 
-{.snap}`Snap` (formerly BYOB) is an extended reimplementation of Scratch
+[Snap!]{.snap} (formerly BYOB) is an extended reimplementation of Scratch
 (<u>https://scratch.mit.edu</u>) that allows you to Build Your Own
 Blocks. It also features ﬁrst class lists, first class procedures, first
 class sprites, first class costumes, first class sounds, and first class
@@ -27,21 +27,21 @@ continuations. These added capabilities make it suitable for a serious
 introduction to computer science for high school or college students.
 
 In this manual we sometimes make reference to Scratch, e.g., to explain
-how some {.snap}`Snap` feature extends something familiar in Scratch. It’s
+how some [Snap!]{.snap} feature extends something familiar in Scratch. It’s
 very helpful to have some experience with Scratch before reading this
 manual, but not essential.
 
-To run {.snap}`Snap`, open a browser window and
-visit [`https://snap.berkeley.edu/snap`](https://snap.berkeley.edu/snap). The {.snap}`Snap` community web site
+To run [Snap!]{.snap}, open a browser window and
+visit [`https://snap.berkeley.edu/snap`](https://snap.berkeley.edu/snap). The [Snap!]{.snap} community web site
 at https://snap.berkeley.edu is covered briefly in @sec-appendix-community
 
 
 The manual is roughly organized into a few sections.
 
 * Chapters 1 to 11 cover the primary features for writing programings in
-Snap*!*. They are organized from introductory to advanced topics.
-* Chapters 12 and 13 cover the user interface components of both the Snap*!* editor and the community site.
-* The appendicies provide [documentation for every block in {.snap}`Snap` block][blocks], as well as some of libraries provided.
+[Snap!]{.snap}. They are organized from introductory to advanced topics.
+* Chapters 12 and 13 cover the user interface components of both the [Snap!]{.snap} editor and the community site.
+* The appendicies provide [documentation for every block in [Snap!]{.snap} block][blocks], as well as some of libraries provided.
 
 [blocks]: /blocks/
 

--- a/manual-index.md
+++ b/manual-index.md
@@ -1,4 +1,4 @@
-# The Snap_!_ Manual Index
+# The [Snap!]{.snap} Manual Index
 
 ```{show-index}
 ```


### PR DESCRIPTION
## Standardize "Snap!" stylization with italic `!` across the project

Fixes inconsistent rendering of the "Snap!" brand name across HTML and PDF/LaTeX outputs. Previously, the `!` was injected via CSS `::after` content, which meant it was invisible to the sidebar, TOC, page `<title>`, and search indexing. This PR puts the `!` in actual document text and ensures it renders in italics in both HTML and LaTeX.

## Changes

- **Canonical syntax**: All occurrences of `Snap!` in source files now use `[Snap!]{.snap}` (bracketed span). Legacy `` {.snap}`Snap` `` code-span form is still accepted by the filter.
- **Lua filter** (`_support/scripts/replace-snap.lua`): Rewritten to handle both `Span` and `Code` elements with `.snap` class, normalize trailing `!` (stripping and re-adding it), and emit format-aware output — `<span class="snap">…<em>!</em></span>` for HTML and `Snap\textit{!}` for LaTeX. Now runs for HTML builds as well as PDF.
- **`_quarto.yml`**: Wired `replace-snap.lua` into the HTML filter chain (was PDF-only). Updated `book.title` to use `[Snap!]{.snap}` syntax.
- **SCSS** (`_support/styles/snap-manual.scss`): Removed `.snap::after { content: '!' }`. Added `.snap em` rule to apply italic styling to the inner `<em>` tag that the filter now emits.
- **Source migration**: Updated ~24 markdown files and `blocks/render-block.py` to use the canonical `[Snap!]{.snap}` form, including compound names like `[SciSnap!]{.snap}`.
- **`STYLEGUIDE.md`**: Documents `[Snap!]{.snap}` as the canonical syntax, notes the legacy form is still accepted, and explains how to handle YAML metadata edge cases.

---

[Superconductor Ticket Implementation](https://www.superconductor.com/tickets/pLr79wzzJWft/implementations/RbHHpJPRB9bG) | [Guided Review](https://www.superconductor.com/tickets/pLr79wzzJWft/implementations/RbHHpJPRB9bG?tab=guided_review)

<!-- created-by-superconductor -->