### PR TITLE
Review Quarto to JupyterBook 2 conversion of Chapter 1 and draft Chapter 2

### DIFF
--- a/01-blocks-scripts-and-sprites.md
+++ b/01-blocks-scripts-and-sprites.md
@@ -14,27 +14,27 @@ using the keyboard, the {.snap}`Snap` programmer uses the same drag-and-drop
 interface familiar to computer users.
 
 Start {.snap}`Snap`. You should see the following
-arrangement of regions\index{layout, window} in the window:
+arrangement of regions{index}`layout, window` in the window:
 
 ![An annotated screenshot of blank Snap! editor](./12-user-interface-elements/assets/snap-ide-annotated.png)
 
 (The proportions of these areas may be different, depending on the size
 and shape of your browser window.)
 
-A {.snap}`Snap` program\index{"Snap! program"} consists of one or more
+A {.snap}`Snap` program{index}`"Snap! program"` consists of one or more
 *scripts,* each of which is made of *blocks.* Here’s a typical script
-\index{script} :
+{index}`script` :
 
 ![image6.png](images/01-blocks-scripts-and-sprites/image6.png){#fig-draw-square}
 
-The five blocks\index{block} that make up this script have three different
+The five blocks{index}`block` that make up this script have three different
 colors, corresponding to three of the eight *palettes* in which blocks
-can be found. The palette\index{palette} area at the left edge of the
+can be found. The palette{index}`palette` area at the left edge of the
 window shows one palette at a time, chosen with the eight buttons just
 above the palette area. In this script, the gold blocks are from the
 Control palette; the green block is from the Pen palette; and the blue
 blocks are from the Motion palette. A script is assembled by dragging
-blocks from a palette into the *scripting area*\index{scripting area}
+blocks from a palette into the *scripting area*{index}`scripting area`
 in the middle part of the window. Blocks snap together (hence the name
 {.snap}`Snap` for the language) when you drag a block so that its indentation
 is near the tab of the one above it:
@@ -60,48 +60,48 @@ be run when the {index}`green flag<single: flag, green>` near the right end of t
 {.snap}`Snap` {index}`tool bar` is clicked. (The {.snap}`Snap` tool bar is
 part of the {.snap}`Snap` window, not the same as the browser’s or operating
 system’s menu bar.) A script isn’t required to have a hat block
-\index{block!hat}, but if not, then the script will be run only if the
+{index}`block!hat`, but if not, then the script will be run only if the
 user clicks on the script itself. A script can’t have more than one hat
 block, and the hat block can be used only at the top of the script; its
 distinctive shape is meant to remind you of
 that.[^1]
 
 <!-- TODO: Different CSS for an inline hat block? -->
-[^1]: One of the hat blocks, the generic\index{hat block!generic}
+[^1]: One of the hat blocks, the generic{index}`hat block!generic`
 “when anything” block ![generic when hat block](images/01-blocks-scripts-and-sprites/image10.png){.image-inline #fig-generic-when}, is subtly different from the others. When the stop
 sign is clicked, or when a project or sprite is loaded, this block
 doesn’t test whether the condition in its hexagonal input slot is true,
 so the script beneath it will not run, until some *other* script in the
 project runs (because, for example, you click the green flag). When
 {index}`generic when` blocks are disabled, the stop sign
-\index{stop sign, square} will be square\index{square stop sign}
+{index}`stop sign, square` will be square{index}`square stop sign`
 instead of octagonal. {#para-generic-when}
 
 The other blocks in our example script are *command* blocks
-\index{block!command}. Each {index}`command block`
+{index}`block!command`. Each {index}`command block`
 corresponds to an action that {.snap}`Snap` already knows how to carry out.
-For example, the block ![image9.png](./blocks/images/block_forward.png){.image-inline} tells the sprite\index{sprite} (the arrowhead
-shape on the *stage*\index{stage} at the right end of the window) to
+For example, the block ![image9.png](./blocks/images/block_forward.png){.image-inline} tells the sprite{index}`sprite` (the arrowhead
+shape on the *stage*{index}`stage` at the right end of the window) to
 move ten steps (a step is a very small unit of distance) in the
 direction in which the arrowhead is pointing. We’ll see shortly that
 there can be more than one sprite, and that each sprite has its own
 scripts. Also, a sprite doesn’t have to look like an arrowhead, but can
-have any picture as a *costume.*\index{costume} The shape of the
-move block is meant to remind you of a Lego™ brick; a script\index{script} is a stack of blocks\index{stack of blocks}. (The word “block” denotes both the graphical shape on the screen and the procedure\index{procedure},
+have any picture as a *costume.*{index}`costume` The shape of the
+move block is meant to remind you of a Lego™ brick; a script{index}`script` is a stack of blocks{index}`stack of blocks`. (The word “block” denotes both the graphical shape on the screen and the procedure{index}`procedure`,
 the action, that the block carries out.)
 
 The number 10 in the `move` block above is called an *input* to the block. By
 clicking on the white oval, you can type any number in place of the 10.
 The sample script on the previous page uses 100 as the input
-\index{input} value. We’ll see later that inputs can have non-oval
+{index}`input` value. We’ll see later that inputs can have non-oval
 shapes that accept values other than numbers. We’ll also see that you
 can compute input values, instead of typing a particular value into the
 oval. A block can have more than one input slot. For example, the `glide`
 block located about halfway down the Motion palette has three inputs.
 
 Most command blocks have that brick shape, but some, like the `repeat`
-block\index{repeat block} in the sample script, are *C‑shaped.* Most
-C-shaped blocks\index{block!C-shaped}\index{C-shaped block} are found
+block{index}`repeat block` in the sample script, are *C‑shaped.* Most
+C-shaped blocks{index}`block!C-shaped`{index}`C-shaped block` are found
 in the {index}`Control palette`. The slot inside the C
 shape is a special kind of input slot that accepts a *script* as the
 input.
@@ -161,14 +161,14 @@ blocks into the desired slot.)
 
 ## Sprites and Parallelism {#sec-sprites-parallelism}
 
-Just below the stage is the “new sprite button\index{new sprite button}”
+Just below the stage is the “new sprite button{index}`new sprite button`”
 ![image25.png](images/01-blocks-scripts-and-sprites/image25.png){.image-inline}. Click the button to add a new sprite to the stage. The new
 sprite will appear in a random position on the stage, with a random
 color, but always facing to the right.
 
 Each sprite has its own scripts. To see the scripts for a particular
 sprite in the scripting area, click on the picture of that sprite in the
-*sprite corral*\index{sprite corral} in the bottom right corner of the
+*sprite corral*{index}`sprite corral` in the bottom right corner of the
 window. Try putting one of the following scripts in each sprite’s
 scripting area:
 
@@ -181,7 +181,7 @@ scripting area:
 When you click the green flag, you should see one sprite rotate while
 the other moves back and forth. This experiment illustrates the way
 different scripts can run in parallel. The turning and the moving happen
-together. Parallelism\index{parallelism} can be seen with multiple
+together. Parallelism{index}`parallelism` can be seen with multiple
 scripts of a single sprite also. Try this example:
 
 ::: {.evenly-spaced-images layout-ncol=2}
@@ -199,7 +199,7 @@ of the tool bar.)
 
 ### Costumes and Sounds
 
-To change the appearance of a sprite, paint or import a new *costume*\index{costume} for it. To paint a costume, click on the Costumes tab above the
+To change the appearance of a sprite, paint or import a new *costume*{index}`costume` for it. To paint a costume, click on the Costumes tab above the
 scripting area, and click the paint button ![image32.png](images/01-blocks-scripts-and-sprites/image32.png). The *Paint Editor* that
 appears is explained in @sec-the-paint-editor. There are three
 ways to import a costume. First select the desired sprite in the sprite
@@ -216,14 +216,14 @@ area will be replaced by something like this:
 ![image31.png](images/01-blocks-scripts-and-sprites/image31.png)
 
 Just above this part of the window is a set of three tabs: Scripts,
-Costumes, and Sounds. You’ll see that the Costumes tab\index{Costumes
-tab} is now selected. In this view, the sprite’s *wardrobe,*
-\index{wardrobe} you can choose whether the sprite should wear its
-Turtle costume or its Alonzo\index{Alonzo} costume. (Alonzo, the
+Costumes, and Sounds. You’ll see that the Costumes tab{index}`Costumes
+tab` is now selected. In this view, the sprite’s *wardrobe,*
+{index}`wardrobe` you can choose whether the sprite should wear its
+Turtle costume or its Alonzo{index}`Alonzo` costume. (Alonzo, the
 {.snap}`Snap` mascot, is named after {index}`Alonzo Church<single: Church, Alonzo>`, a
 mathematician who invented the idea of procedures as data
-\index{procedures as data}, the most important way in which {.snap}`Snap` is
-different from Scratch\index{Scratch}.) You can give a sprite as many
+{index}`procedures as data`, the most important way in which {.snap}`Snap` is
+different from Scratch{index}`Scratch`.) You can give a sprite as many
 costumes as you like, and then choose which it will wear either by
 clicking in its wardrobe or by using the ![image35.png](./blocks/images/block_doSwitchToCostume.png){.image-inline} or ![Next Costume](./blocks/images/block_doWearNextCostume.png){.image-inline} block in a script.
 (Every costume has a number as well as a name. The `next` costume block
@@ -237,8 +237,8 @@ Protip: ![Switch to costumer (() - 1)](images/01-blocks-scripts-and-sprites/imag
 :::
 
 In addition to its costumes, a sprite can have *sounds;* the equivalent for
-sounds of the sprite’s wardrobe is called its *jukebox.*\index{jukebox}
-Sound files\index{play sound block} can be imported in any format
+sounds of the sprite’s wardrobe is called its *jukebox.*{index}`jukebox`
+Sound files{index}`play sound block` can be imported in any format
 (WAV, OGG, MP3, etc.) supported by your browser. Two blocks accomplish
 the task of {index}`playing sounds`. If you would like a
 script to continue running while the sound is playing, use the block ![image39.png](images/01-blocks-scripts-and-sprites/image39.png).
@@ -273,7 +273,7 @@ message is sent to *every* sprite, which is why the block is called
 the block becomes ![image45.png](images/01-blocks-scripts-and-sprites/image45.png){.image-inline}, and you can change it to ![image46.png](images/01-blocks-scripts-and-sprites/image46.png){.image-inline} to send the message just
 to one sprite.) In this program, though, only one sprite has a script to
 run when that broadcast is sent, namely the dog. Because the boy’s
-script uses `broadcast and wait`\index{broadcast and wait block} rather
+script uses `broadcast and wait`{index}`broadcast and wait block` rather
 than just broadcast, the boy doesn’t go on to his next say block until
 the dog’s script finishes. That’s why the two sprites take turns
 talking, instead of both talking at once. In @sec-ch07 you’ll see a more flexible
@@ -290,7 +290,7 @@ dots are *not* shown on the stage if the text is displayed.
 
 The stage has its own scripting area. It can be selected by clicking on
 the Stage icon at the left of the sprite corral. Unlike a sprite,
-though, the stage can’t move. Instead of costumes, it has *backgrounds:*\index{backgrounds}
+though, the stage can’t move. Instead of costumes, it has *backgrounds:*{index}`backgrounds`
 pictures that fill the entire stage area. The sprites appear in front of
 the current background. In a complicated project, it’s often convenient
 to use a script in the stage’s scripting area as the overall director of
@@ -302,10 +302,10 @@ Sometimes it’s desirable to make a sort of “super-sprite” composed of
 pieces that can move together but can also be separately articulated.
 The classic example is a person’s body made up of a torso, limbs, and a
 head. {.snap}`Snap` allows one sprite to be designated as the *anchor*
-\index{anchor} of the combined shape, with other sprites as its *parts.*
-\index{parts (of nested sprite)}
+{index}`anchor` of the combined shape, with other sprites as its *parts.*
+{index}`parts (of nested sprite)`
 
-To set up sprite nesting \index{sprite nesting}, drag the sprite corral icon of a *part* sprite
+To set up sprite nesting {index}`sprite nesting`, drag the sprite corral icon of a *part* sprite
 onto the stage display (not the sprite corral icon!) of the desired
 *anchor* sprite. The precise place where you let go of the mouse button
 will be the attachment point of the part on the anchor.
@@ -321,8 +321,8 @@ probably.) Sprite, representing Alonzo’s body, is the anchor; Sprite(2)
 is the arm. The icon for the anchor shows small images of up to three
 attached parts at the bottom. The icon for each part shows a small image
 of the anchor in its top left corner, and a *synchronous*
-\index{synchronous rotation} *dangling rotation*\index{dangling
-rotation} *flag* in the top right corner. In its initial, synchronous
+{index}`synchronous rotation` *dangling rotation*{index}`dangling
+rotation` *flag* in the top right corner. In its initial, synchronous
 setting, as shown above, it means that the when the anchor sprite
 rotates, the part sprite also rotates as well as revolving around the
 anchor. When clicked, it changes from a circular arrow to a straight
@@ -342,16 +342,16 @@ the arm synchronous (left) and dangling (right).*
 ## Reporter Blocks and Expressions
 
 So
-far, we’ve used two kinds of blocks\index{block!reporter}: hat blocks
-and command blocks. Another kind is the *reporter* block,\index{Reporter
-block} which has an oval shape: ![image66.png](images/01-blocks-scripts-and-sprites/image66.png) <!-- {width=0.72917in height=0.15625in} --> . It’s called a “reporter” because
+far, we’ve used two kinds of blocks{index}`block!reporter`: hat blocks
+and command blocks. Another kind is the *reporter* block,{index}`Reporter
+block` which has an oval shape: ![image66.png](images/01-blocks-scripts-and-sprites/image66.png) <!-- {width=0.72917in height=0.15625in} --> . It’s called a “reporter” because
 when it’s run, instead of carrying out an action, it reports a value
 that can be used as an input to another block. If you drag a ![image65.png](images/01-blocks-scripts-and-sprites/image65.png){.image-inline} <!-- {width=1.47in height=0.52in} --> reporter
 into the scripting area by itself and click on it, the value it reports
 will appear in a speech balloon next to the block:
 
 When you drag a reporter block over another block’s input slot, a white
-“halo\index{halo} ” appears around that input slot, analogous to the
+“halo{index}`halo` ” appears around that input slot, analogous to the
 white line that appears when snapping command blocks together:
 
 ![image67.png](images/01-blocks-scripts-and-sprites/image67.png) <!-- {width=1.47in height=0.52in} -->
@@ -372,7 +372,7 @@ to the center of the stage. Similarly, the {index}`Y position`
 is measured vertically, in steps above (positive) or below (negative)
 the center.)
 
-You can do arithmetic\index{arithmetic} using reporters in the
+You can do arithmetic{index}`arithmetic` using reporters in the
 Operators palette:
 
 ![image73.png](images/01-blocks-scripts-and-sprites/image73.png) <!--  style="width:2.11111in;height:0.61806in" alt="Macintosh HD:Users:bh:Desktop:Google Chrome001.png" / -->
@@ -386,17 +386,17 @@ block is nested inside another block from the same palette:
 ![image80.png](images/01-blocks-scripts-and-sprites/image80.png) <!-- {width=4.85417in height=1.90625in} -->
 
 This
-aid to readability is called *zebra coloring.*\index{zebra coloring}
+aid to readability is called *zebra coloring.*{index}`zebra coloring`
 A reporter block with its inputs, maybe including other reporter
-blocks, such as ![image81.png](images/01-blocks-scripts-and-sprites/image81.png) <!-- {width=1.91667in height=0.23958in} -->, is called an *expression.*\index{expression}
+blocks, such as ![image81.png](images/01-blocks-scripts-and-sprites/image81.png) <!-- {width=1.91667in height=0.23958in} -->, is called an *expression.*{index}`expression`
 
 ##  Predicates and Conditional Evaluation {#sec-sec-predicates-and-conditional-evaluation}
 
-Most reporters report\index{block!predicate} either a number, like ![image82.png](./blocks/images/block_reportVariadicSum.png){.image-inline},
+Most reporters report{index}`block!predicate` either a number, like ![image82.png](./blocks/images/block_reportVariadicSum.png){.image-inline},
 or a text string, like
 ![image83.png](./blocks/images/block_reportJoinWords.png){.image-inline}.
 A *predicate* is a special kind of reporter that
-always reports true or false. Predicates\index{Predicate block} have a
+always reports true or false. Predicates{index}`Predicate block` have a
 {index}`hexagonal shape`: ![image85.png](./blocks/images/block_reportMouseDown.png){.image-inline}
 
 The special shape is a reminder that predicates don’t generally make sense
@@ -411,8 +411,8 @@ The C-shaped {index}`if block` runs its input script if (and only
 if) the expression in its hexagonal input reports true.
 ![image87.png](images/01-blocks-scripts-and-sprites/image87.png)
 
-A really useful block\index{repeat until block} in animations
-\index{animation} runs its input script *repeatedly* until a predicate
+A really useful block{index}`repeat until block` in animations
+{index}`animation` runs its input script *repeatedly* until a predicate
 is satisfied: ![image89.png](images/01-blocks-scripts-and-sprites/image89.png)
 
 If, while working on a project, you want to omit temporarily some commands
@@ -422,18 +422,18 @@ in a script, but you don’t want to forget where they belong, you can say
 
 Sometimes you want to take the same action whether some condition is
 true or false, but with a different input value. For this purpose you
-can use the *reporter* `if` block\index{reporter if block} :
+can use the *reporter* `if` block{index}`reporter if block` :
 
 ![image90.png](images/01-blocks-scripts-and-sprites/image90.png) <!-- {width=4.20833in height=0.38542in} -->
 
-The technical term for a true or false value is a “Boolean\index{Boolean} ”
+The technical term for a true or false value is a “Boolean{index}`Boolean` ”
 value; it has a capital B because it’s named after a person, George
-Boole\index{Boole, George}, who developed the mathematical theory of
+Boole{index}`Boole, George`, who developed the mathematical theory of
 Boolean values. Don’t get confused; a hexagonal block is a *predicate,*
 but the value it reports is a *Boolean.*
 
 Another quibble about vocabulary: Many programming languages reserve the
-name “procedure\index{procedure}” for Commands (that carry out an
+name “procedure{index}`procedure`” for Commands (that carry out an
 action) and use the name “function” for Reporters and Predicates. In
 this manual, a *procedure* is any computational capability, including
 those that report values and those that don’t. Commands, Reporters, and
@@ -441,7 +441,7 @@ Predicates are all procedures. The words “a Procedure type” are
 shorthand for “Command type, Reporter type, or Predicate type.”
 
 If you want to put
-a *constant* Boolean\index{Boolean constant} value in a hexagonal slot
+a *constant* Boolean{index}`Boolean constant` value in a hexagonal slot
 instead of a predicate-based expression, hover the mouse over the block
 and click on the control that appears:
 
@@ -464,14 +464,14 @@ number input to the `for` block from the default 10 to 200, and before
 dragging in a `turn` block.)
 `For` runs its script input repeatedly, just
 like `repeat`, but before each repetition it sets the variable
-\index{variable} <var>i</var> to a number starting with its first numeric input,
+{index}`variable` <var>i</var> to a number starting with its first numeric input,
 adding 1 for each repetition, until it reaches the second numeric input.
 In this case, there will be 200 repetitions, first with <var>i</var>=1, then with
 <var>i</var>=2, then <var>i</var>=3, and so on until <var>i</var>=200 for the final repetition. The result
 is that each move draws a longer and longer line segment, and that’s why
 the picture you see is a kind of spiral. (If you try again with a turn
 of 90 degrees instead of 92, you’ll see why this picture is called a
-“squiral\index{squiral}.”)
+“squiral{index}`squiral`.”)
 
 The
 variable <var>i</var> is created by the `for` block, and it can only be used in the
@@ -487,11 +487,11 @@ tend to use letters between <var>i</var> and <var>n</var> to represent integer v
 programming languages we don’t have to restrict ourselves to
 single-letter variable names.)
 
-### Global Variable\index{variable!global}s\index{global variable}
+### Global Variable{index}`variable!global`s{index}`global variable`
 
 You can create variables “by hand” that aren’t limited to being used
 within a single block. At the top of the Variables palette, click the
-“Make a variable\index{Make a variable}” button:
+“Make a variable{index}`Make a variable`” button:
 
 ![image97.png](images/01-blocks-scripts-and-sprites/image97.png) <!-- {width=2.05208in height=2.27083in} -->
 
@@ -502,7 +502,7 @@ name:
 
 The dialog also gives you a choice to make the variable available to all
 sprites (which is almost always what you want) or to make it visible
-only in the current sprite\index{sprite-local variable}. You’d do that
+only in the current sprite{index}`sprite-local variable`. You’d do that
 if you’re going to give several sprites individual variables *with the
 same name,* so that you can share a script between sprites (by dragging
 it from the current sprite’s scripting area to the picture of another
@@ -517,15 +517,15 @@ look like this:
 ![image98.png](images/01-blocks-scripts-and-sprites/image98.png) <!-- {width=1.65833in height=2.29167in} -->
 
 There’s
-now a “Delete a variable\index{Delete a variable}” button, and there’s
+now a “Delete a variable{index}`Delete a variable`” button, and there’s
 an orange oval with the variable name in it, just like the orange oval
 in the for block. You can drag the variable into any script in the
 scripting area. Next to the oval is a checkbox, initially checked. When
-it’s checked, you’ll also see a *variable watcher*\index{variable
-watcher} on the stage: ![image99.png](images/01-blocks-scripts-and-sprites/image99.png) <!-- {width=1.04167in height=0.40625in} -->
+it’s checked, you’ll also see a *variable watcher*{index}`variable
+watcher` on the stage: ![image99.png](images/01-blocks-scripts-and-sprites/image99.png) <!-- {width=1.04167in height=0.40625in} -->
 
 When you give the variable a value, the orange box in its watcher
-\index{watcher} will display the value.
+{index}`watcher` will display the value.
 
 How *do* you give it a value?
 You use the {index}`\`set\` block<`set` block>` :
@@ -535,24 +535,24 @@ Note that you *don’t* drag the variable’s oval into the `set` block! You
 click on the downarrow in the first input slot, and you get a menu of
 all the available variable names.
 
-If you do choose “For this sprite only\index{For this sprite only} ”
+If you do choose “For this sprite only{index}`For this sprite only` ”
 when creating a variable, its block in the palette looks like this:![image101.png](images/01-blocks-scripts-and-sprites/image101.png) <!--  style="width:0.65833in;height:0.14167in" alt="Macintosh HD:Users:bh:Desktop:local-var.png" / -->
 
 The *location*-pin
-\index{location-pin} icon is a bit of a pun on a sprite-*local* variable
-\index{variable!sprite-local}. It’s shown only in the palette.
+{index}`location-pin` icon is a bit of a pun on a sprite-*local* variable
+{index}`variable!sprite-local`. It’s shown only in the palette.
 
 ### Script Variables
 
 In the name example above, our project is going to carry on an
-interaction\index{interaction} with the user, and we want to remember
+interaction{index}`interaction` with the user, and we want to remember
 their name throughout the project. That’s a good example of a situation
-in which a *global* variable\index{global variable} (the kind you make
+in which a *global* variable{index}`global variable` (the kind you make
 with the “Make a variable” button) is appropriate. Another common
 example is a variable called “score” in a game project. But sometimes
-you only need a variable\index{variable!script-local} temporarily,
+you only need a variable{index}`variable!script-local` temporarily,
 during the running of a particular script. In that case you can use the
-script variables block\index{script variables block} to make the
+script variables block{index}`script variables block` to make the
 variable:
 
 ![image105.png](images/01-blocks-scripts-and-sprites/image105.png) <!-- {width=2.08333in height=0.30208in} -->
@@ -607,7 +607,7 @@ all,” then the name will be changed throughout the scope of the variable
 
 
 
-### Transient variables\index{variable!transient}
+### Transient variables{index}`variable!transient`
 
 So far we’ve talked about
 variables with numeric values, or with short text strings such as
@@ -619,7 +619,7 @@ see how to read information from web sites.
 ![image102.png](images/01-blocks-scripts-and-sprites/image102.png) <!-- {width=2.08333in height=0.30208in} -->
 
 When you use these
-capabilities, your project may take up a lot of memory\index{memory} in
+capabilities, your project may take up a lot of memory{index}`memory` in
 the computer. If you get close to the amount of memory available to
 {.snap}`Snap`, then it may become impossible to save your project. (Extra
 space is needed temporarily to convert from {.snap}`Snap`’s internal
@@ -630,14 +630,14 @@ containing a lot of data removed from memory before saving the project.
 To do this, right-click or control-click on the orange oval in the
 Variables palette, to see this menu: ![image114.png](images/01-blocks-scripts-and-sprites/image114.png) <!-- {width=1.29167in height=1.05556in} -->
 
-You already know about the rename options, and "help…"\index{help} displays a help
+You already know about the rename options, and "help…"{index}`help` displays a help
 screen about variables in general. Here we’re interested in the check
 box next to transient. If you check it, this variable’s value will not
 be saved when you save your project. Of course, you’ll have to ensure
 that when your project is loaded, it recreates the needed value and sets
 the variable to it.
 
-## Debugging\index{Debugging}
+## Debugging{index}`Debugging`
 
 {.snap}`Snap` provides several tools to help you debug a program. They center
 around the idea of *pausing* the running of a script partway through, so
@@ -646,16 +646,16 @@ that you can examine the values of variables.
 ### The pause button
 
 The simplest way to pause a
-program is manually, by clicking the pause button ![image116.png](images/01-blocks-scripts-and-sprites/image116.png) <!-- {width=0.29167in height=0.16667in} -->\index{button!pause}
+program is manually, by clicking the pause button ![image116.png](images/01-blocks-scripts-and-sprites/image116.png) <!-- {width=0.29167in height=0.16667in} -->{index}`button!pause`
 in the top right corner of the window. While the program is paused, you
 can run other scripts by clicking on them, show variables on stage with
 the checkbox next to the variable in the Variables palette or with the
-`show variable`block\index{hide variable block}, and do all the other
+`show variable`block{index}`hide variable block`, and do all the other
 things you can generally do, including modifying the paused scripts by
 adding or removing blocks. The ![image115.png](images/01-blocks-scripts-and-sprites/image115.png) <!-- {width=0.29167in height=0.16667in} -->  button changes shape too and clicking it
 again resumes the paused scripts.
 
-### Breakpoints\index{breakpoint} : the `pause all` block\index{pause all block} {#sec-pause-all}
+### Breakpoints{index}`breakpoint` : the `pause all` block{index}`pause all block` {#sec-pause-all}
 
 The pause button is great if your program seems to be in an infinite loop,
 but more often you’ll want
@@ -678,7 +678,7 @@ only errors when a particular condition is true — for example, when the value 
 variable is negative, which shouldn’t ever happen. In the iteration
 library (see @sec-libraries-intro for more about how to use
 libraries) is a breakpoint block that lets you set a *conditional*
-breakpoint\index{conditional breakpoint}, and automatically display the relevant variables before pausing. Here’s a sample use of it:
+breakpoint{index}`conditional breakpoint`, and automatically display the relevant variables before pausing. Here’s a sample use of it:
 
 ![image119.png](images/01-blocks-scripts-and-sprites/image119.png) <!-- {width=1.19444in height=1.33333in} -->
 
@@ -689,9 +689,9 @@ variable watchers are removed by this breakpoint block before resuming
 the script. The breakpoint block isn’t magic; you could alternatively
 just put a `pause all` inside an `if`.[^2]
 
-[^2]: The hide variable and\index{hide variable block} show variable
-block\index{show variable block} s can also be used to hide and show
-primitives\index{hide and show primitives} in the palette. The pulldown
+[^2]: The hide variable and{index}`hide variable block` show variable
+block{index}`show variable block` s can also be used to hide and show
+primitives{index}`hide and show primitives` in the palette. The pulldown
 menu doesn’t include primitive blocks, but there’s a generally useful
 technique to give a block input values it wasn’t expecting using run or
 call:![image120.png](images/01-blocks-scripts-and-sprites/image120.png) <!-- {width=3.9375in height=0.38889in} --> <br>
@@ -705,7 +705,7 @@ Sometimes you’re not exactly sure where the error is, or you don’t
 understand how the program got there. To understand better, you’d
 like to watch the program as it runs, at human speed rather than
 at computer speed. You can do this by
-clicking the *visible stepping*\index{button!visible stepping} button\index{visible stepping button} (![image121.png](images/01-blocks-scripts-and-sprites/image121.png) <!-- {width=0.29167in height=0.16667in} --> ), before running a script or
+clicking the *visible stepping*{index}`button!visible stepping` button{index}`visible stepping button` (![image121.png](images/01-blocks-scripts-and-sprites/image121.png) <!-- {width=0.29167in height=0.16667in} --> ), before running a script or
 while the script is paused. The button will light up ( ![image123.png](images/01-blocks-scripts-and-sprites/image123.png) <!-- {width=0.29167in height=0.16667in} --> ) and a speed
 control slider ![image122.png](images/01-blocks-scripts-and-sprites/image122.png) <!-- {width=0.54563in height=0.15278in} --> will appear in the toolbar. When you start or continue
 the script, its blocks and input slots will light up cyan one at a time:
@@ -719,11 +719,11 @@ that the input to a block is evaluated before the block itself is
 called, so, for example, the 100 lights up before the move.
 
 The speed of stepping is
-controlled by the slider\index{slider!stepping speed}. If you move the
+controlled by the slider{index}`slider!stepping speed`. If you move the
 slider all the way to the left, the speed is zero, the pause button
 turns into a step button ![image134.png](images/01-blocks-scripts-and-sprites/image134.png) <!-- {width=0.29167in height=0.16667in} --> , and the script takes a single step each time
-you push it. The name for this is *single stepping.*\index{single
-stepping}
+you push it. The name for this is *single stepping.*{index}`single
+stepping`
 
 If several scripts that are visible in the scripting area are running at
 the same time, all of them are stepped in parallel. However, consider
@@ -750,13 +750,13 @@ at least part of its name, type <kbd>control-F</kbd> and enter the name in the t
 Here are some of the primitive blocks that don’t exist in Scratch:
 
 ![image136.png](images/01-blocks-scripts-and-sprites/image136.png)
-reports\index{pen trails
-block}\index{pen vectors block}, a new costume consisting of everything
+reports{index}`pen trails
+block`{index}`pen vectors block`, a new costume consisting of everything
 that’s drawn on the stage by any sprite. Right-clicking the block in the
 scripting area gives the option to change it to ![image135.png](images/01-blocks-scripts-and-sprites/image135.png) if vector logging is enabled. See @para-log-pen-vectors.
 
 ![image137.png](images/01-blocks-scripts-and-sprites/image137.png){.image-inline} Print
-characters\index{write block} in the given point size on the stage, at
+characters{index}`write block` in the given point size on the stage, at
 the sprite’s position and in its direction. The sprite moves to the end
 of the text. (That’s not always what you want, but you can save the
 sprite’s position before using it, and sometimes you need to know how
@@ -776,17 +776,17 @@ Takes a sprite as input. Erases from that sprite’s costume the area that overl
 ![image140.png](images/01-blocks-scripts-and-sprites/image140.png){.image-inline} Runs only this script until finished. In the Control palette even though it’s gray.
 
 ![image143.png](images/01-blocks-scripts-and-sprites/image143.png){.image-inline} <!--  style="width:1.71in;height:0.23in" alt="Macintosh HD:Users:bh:Desktop:pix:reporter-if.png" / --> Reporter
-version of the `if/else` primitive command block\index{if else reporter
-block} . Only one of the two branches is evaluated, depending on the
+version of the `if/else` primitive command block{index}`if else reporter
+block` . Only one of the two branches is evaluated, depending on the
 value of the first input.
 
 ![image144.png](images/01-blocks-scripts-and-sprites/image144.png){.image-inline} <!--  style="width:1.83in;height:0.61in" alt="Macintosh HD:Users:bh:Desktop:pix:for.png" / --> Looping block like
-`repeat` but\index{for block} with an index variable\index{index
-variable} .
+`repeat` but{index}`for block` with an index variable{index}`index
+variable` .
 
 ![image145.png](images/01-blocks-scripts-and-sprites/image145.png){.image-inline} <!--  style="width:1.37986in;height:0.28958in" alt="Graphical user interface, application, logo Description automatically generated" / --> Declare
-{index}`local variables` in a script.\index{script
-variables block}
+{index}`local variables` in a script.{index}`script
+variables block`
 
 ![image148.png](images/01-blocks-scripts-and-sprites/image148.png){.image-inline} See @sec-ch09.
 
@@ -797,18 +797,18 @@ variables block}
 ![image149.png](images/01-blocks-scripts-and-sprites/image149.png){.image-inline}
 
 ![image153.png](images/01-blocks-scripts-and-sprites/image153.png){.image-inline}
-Create a primitive using JavaScript\index{JavaScript}. (This block is
+Create a primitive using JavaScript{index}`JavaScript`. (This block is
 disabled by default; the user must check “Javascript extensions” in the
-setting menu *each time* a project is loaded.)\index{pen down? block}
+setting menu *each time* a project is loaded.){index}`pen down? block`
 
 ::: {.evenly-spaced-images layout-ncol=2}
 ![image150.png](images/01-blocks-scripts-and-sprites/image150.png){.image-inline}
 
 The {index}`\`at\` block<`at` block>` lets you examine the screen pixel
-\index{screen pixel} directly behind the rotation center of a sprite,
+{index}`screen pixel` directly behind the rotation center of a sprite,
 the mouse, or an arbitrary (x,y) coordinate pair dropped onto the second
 menu slot. The first five items of the left menu let you examine the
-color visible at the position. (The “RGBA” option\index{RGBA option}
+color visible at the position. (The “RGBA” option{index}`RGBA option`
 reports a list.) The “sprites” option reports a list of all sprites,
 including this one, any point of which overlaps this sprite’s rotation
 center (behind or in front). This is a hyperblock with respect to its
@@ -818,47 +818,47 @@ second input.
 <!-- This needs 2 columns ??? -->
 ![image154.png](images/01-blocks-scripts-and-sprites/image154.png){.image-4x}
 
-Checks the\index{is-a-block@`is \_ a \_ ?` block} data\index{stage blocks} type\index{type} of a value.
+Checks the{index}`is-a-block@`is \_ a \_ ?` block` data{index}`stage blocks` type{index}`type` of a value.
 
 <!-- These two need to be remade as text -->
 ![image151.png](images/01-blocks-scripts-and-sprites/image151.png){.image-4x}
 ![image152.png](images/01-blocks-scripts-and-sprites/image152.png){.image-4x}
 
 ::: {layout-ncol=2}
-![image155.png](images/01-blocks-scripts-and-sprites/image155.png){.image-4x}\index{set flag block}
+![image155.png](images/01-blocks-scripts-and-sprites/image155.png){.image-4x}{index}`set flag block`
 
 {index}`Turn the` text into a list,
 using the second input as the delimiter between items. The default
 delimiter, indicated by the brown dot in the input slot, is a single
 space character. “Letter” puts each character of the text in its own
-list item. “Word” puts each word in an item. (\index{whitespace} Words
+list item. “Word” puts each word in an item. ({index}`whitespace` Words
 are separated by any number of consecutive space, tab, carriage return,
-or newline characters.) “Line” is a newline character\index{newline
-character} (0xa); “tab” is a {index}`tab character` (0x9);
-“cr” is a carriage return\index{carriage return character} (0xd). “Csv”
-\index{CSV format} and “json”\index{JSON format} split formatted text
+or newline characters.) “Line” is a newline character{index}`newline
+character` (0xa); “tab” is a {index}`tab character` (0x9);
+“cr” is a carriage return{index}`carriage return character` (0xd). “Csv”
+{index}`CSV format` and “json”{index}`JSON format` split formatted text
 into lists of lists; see @sec-csv. “Blocks”
 takes a script as the first input, reporting a list structure
 representing the structure of the script. See Chapter XI.
 :::
 
 ![image170.png](images/01-blocks-scripts-and-sprites/image170.png){.image-inline} For lists,
-\index{identical to} reports true only if its two input values are the
+{index}`identical to` reports true only if its two input values are the
 very same list, so changing an item in one of them is visible in the
 other. (For `=`, lists that look the same are the same.) For text strings,
 uses case-sensitive comparison, unlike `=`, which is case-independent.
 
 ![image171.png](images/01-blocks-scripts-and-sprites/image171.png){.image-inline} These *hidden* blocks can be found with the relabel option
-\index{relabel option} of any dyadic arithmetic block. They’re hidden
+{index}`relabel option` of any dyadic arithmetic block. They’re hidden
 partly because writing them in {.snap}`Snap` is a good, pretty easy
-programming exercise. Note: the two inputs to `atan2`\index{atan2 block}
+programming exercise. Note: the two inputs to `atan2`{index}`atan2 block`
 are Δ*x* and Δ*y* in that order, because we measure angles clockwise
 from north. `max` /index{max block} and `min` /index{min block} are *variadic;* by clicking the arrowhead, you
 can provide additional inputs.
 
 ![image177.png](images/01-blocks-scripts-and-sprites/image177.png){.image-inline} ![image178.png](images/01-blocks-scripts-and-sprites/image178.png){.image-inline} ![image179.png](images/01-blocks-scripts-and-sprites/image179.png){.image-inline}
 
-Similarly, these\index{*less-than-or-equal@`≤` block} hidden predicates can be found by relabeling the relational predicates.
+Similarly, these{index}`*less-than-or-equal@`≤` block` hidden predicates can be found by relabeling the relational predicates.
 
 ### Metaprogramming (see @sec-ch11)
 
@@ -875,11 +875,11 @@ capability is new in version 8.0.
 <!-- TODO: welp. this needs to be remade -->
 ![image173.png](images/01-blocks-scripts-and-sprites/image173.png)
 
-`Numbers from`\index{numbers from block} will
+`Numbers from`{index}`numbers from block` will
 count up or down.
 
 ![image224.png](images/01-blocks-scripts-and-sprites/image224.png){.image-inline} ![image225.png](images/01-blocks-scripts-and-sprites/image225.png){.image-inline}
-report\index{position block} the sprite or mouse position as a two-item
+report{index}`position block` the sprite or mouse position as a two-item
 vector (x,y).
 
 **First class procedure blocks (see @sec-ch06):**
@@ -900,15 +900,15 @@ vector (x,y).
 
 ![image280.png](images/01-blocks-scripts-and-sprites/image280.png){.image-2x}
 
-The major new feature of version 7.0 is *scenes:*\index{scenes} A project can include
+The major new feature of version 7.0 is *scenes:*{index}`scenes` A project can include
 within it sub-projects, called scenes, each with its own stage, sprites,
 scripts, and so on. This block makes another scene active, replacing the
 current one.
 
 Nothing is automatically shared between scenes: no sprites, no blocks,
 no variables. But the old scene can send a message to the new one, to
-start it running, with optional payload as in broadcast\index{broadcast
-block} (See @sec-broadcast).
+start it running, with optional payload as in broadcast{index}`broadcast
+block` (See @sec-broadcast).
 
 ![image282.png](images/01-blocks-scripts-and-sprites/image282.png){.image-4x}
 
@@ -919,13 +919,13 @@ In particular, you can say
 if the new scene expects to be started with a green flag signal.
 
 ***These aren’t new blocks but they have a new feature:***
-These accept two-item (x,y)\index{points as inputs} lists
-\index{two-item (x,y) lists} as input, and have extended menus (also
-including other sprites):\index{to block}
+These accept two-item (x,y){index}`points as inputs` lists
+{index}`two-item (x,y) lists` as input, and have extended menus (also
+including other sprites):{index}`to block`
 
 ![image283.png](images/01-blocks-scripts-and-sprites/image283.png)
 
-“Center” means the center of the stage\index{center of the stage}, the
+“Center” means the center of the stage{index}`center of the stage`, the
 point at (0,0). “Direction” is in the point in direction sense, the
 direction that would leave this sprite pointing toward another sprite,
 the mouse, or the center. “Ray length” is the distance from the center
@@ -942,23 +942,23 @@ bottom of the block because the current script can continue after it.
 
 ![image285.png](images/01-blocks-scripts-and-sprites/image285.png){.image-2x}
 The new “pen trails” option is true if the sprite is touching any drawn
-or stamped ink on the stage. Also, `touching`\index{touching block} will
+or stamped ink on the stage. Also, `touching`{index}`touching block` will
 not detect hidden sprites, but a hidden sprite can use it to detect
 visible sprites.
 
 ![image305.png](images/01-blocks-scripts-and-sprites/image305.png){.image-inline} <!--  style="width:2.43333in;height:0.3in" alt="Macintosh HD:Users:bh:Desktop:video-on.png" / --> The `video on` block
-\index{video block} has a {index}`snap option` that takes a
+{index}`video block` has a {index}`snap option` that takes a
 snapshot and reports it as a costume. It is hyperized with respect to its second input.
 
 :::{.evenly-spaced-images layout-ncol=2}
 ![image306.png](images/01-blocks-scripts-and-sprites/image306.png){.image-inline}
 
-![image304.png](images/01-blocks-scripts-and-sprites/image304.png){.image-inline} The “neg” option\index{neg option} is a monadic\index{of block
-(operators)}\index{length of text block} negation operator
-\index{negation operator}, equivalent to “lg” is log<sub>2</sub>.
+![image304.png](images/01-blocks-scripts-and-sprites/image304.png){.image-inline} The “neg” option{index}`neg option` is a monadic{index}`of block
+(operators)`{index}`length of text block` negation operator
+{index}`negation operator`, equivalent to “lg” is log<sub>2</sub>.
 “id” is the identity function, which reports its input. “sign” reports 1
 for positive input, 0 for zero input, or -1 for negative input.
-\index{set background block}
+{index}`set background block`
 :::
 
 <!-- ::: {.callout-tip} -->
@@ -976,10 +976,10 @@ changes to `sum` or `product`.
 ::: {.evenly-spaced-images layout-ncol=2}
 ![image309.png](images/01-blocks-scripts-and-sprites/image309.png)
 
-Extended\index{when I am block} mouse interaction events, sensing
+Extended{index}`when I am block` mouse interaction events, sensing
 clicking, dragging, hovering, etc. The “stopped” option triggers when
 all scripts are stopped, as with the stop button; it is useful for
-robots whose hardware interface must be told to turn off motors. A `when I am stopped` script\index{when I am stopped script} can run only for a
+robots whose hardware interface must be told to turn off motors. A `when I am stopped` script{index}`when I am stopped script` can run only for a
 limited time.
 :::
 
@@ -992,7 +992,7 @@ limited time.
 ::: {.evenly-spaced-images layout-ncol=2}
 ![image311.png](images/01-blocks-scripts-and-sprites/image311.png){.image-4x}
 
-Extended `when I receive`\index{when I receive block}: Click the right
+Extended `when I receive`{index}`when I receive block`: Click the right
 arrowhead to expose a script variable (click on it to change its name,
 like any script variable) that will be set to the data of a matching
 broadcast. If the first input is set to “any message,” then the data
@@ -1014,7 +1014,7 @@ is represented as itself in key.)
 
 ![image356.png](images/01-blocks-scripts-and-sprites/image356.png){.image-4x} <!--  style="width:2.25in;height:0.41944in"   alt="Website Description automatically generated with medium confidence" -->
 
-The RGB(A)\index{set pen block} option accepts a single number, which
+The RGB(A){index}`set pen block` option accepts a single number, which
 is a grayscale value 0-255; a two-number list, grayscale plus opacity
 0-255; a three-item RGB list, or a four-item RGBA list.
 
@@ -1022,7 +1022,7 @@ is a grayscale value 0-255; a two-number list, grayscale plus opacity
 ![image358.png](images/01-blocks-scripts-and-sprites/image358.png)
 
 ### Using Lists with the Ask Block {#sec-ask-lists}
-These ask features\index{ask and wait block} and more in the Menus
+These ask features{index}`ask and wait block` and more in the Menus
 library.
 
 ![image359.png](images/01-blocks-scripts-and-sprites/image359.png)
@@ -1036,7 +1036,7 @@ library.
 ::: {.evenly-spaced-images layout-ncol=2}
 ![image363.png](images/01-blocks-scripts-and-sprites/image363.png){.image-4x}
 
-The `of` block\index{of block (sensing)} has an extended menu of
+The `of` block{index}`of block (sensing)` has an extended menu of
 attributes of a sprite. Position reports an (x,y) vector. Size reports
 the percentage of normal size, as controlled by the set size block in
 the Looks category. Left, right, etc. report the stage coordinates of
@@ -1049,7 +1049,7 @@ script variables if the right input is a script.)
 
 There are several collections of useful procedures that aren’t {.snap}`Snap`
 primitives, but are provided as libraries. To include a library in your
-project, choose the Libraries… option\index{Libraries… option} in the
+project, choose the Libraries… option{index}`Libraries… option` in the
 file (![file menu icon](images/01-blocks-scripts-and-sprites/image384.png){.image-inline}) menu.
 
 ![The import libraries dialog](images/01-blocks-scripts-and-sprites/image385.png)
@@ -1086,30 +1086,30 @@ The libraries and their contents may change, but as of this writing the
 
 ![image387.png](images/01-blocks-scripts-and-sprites/image387.png){.image-4x} <!-- {width=1.84861in height=2.49236in} -->
 
-(The lightning bolt (⚡️)\index{*lightning-bolt@⚡️ (lightning bolt)} before the name in several of these
+(The lightning bolt (⚡️){index}`*lightning-bolt@⚡️ (lightning bolt)` before the name in several of these
 blocks means that they use compiled HOFs or JavaScript primitives to achieve
-optimal speed. They are officially considered experimental.) `Remove duplicates from`\index{remove duplicates from block} reports a list in
-which no two items are equal. The `sort`\index{sort block} block takes a
+optimal speed. They are officially considered experimental.) `Remove duplicates from`{index}`remove duplicates from block` reports a list in
+which no two items are equal. The `sort`{index}`sort block` block takes a
 list and a two-input comparison predicate, such as `<`, and reports a
 list with the items sorted according to that comparison. The `assoc` block
-\index{assoc block} is for looking up a key in an *association list:* a
+{index}`assoc block` is for looking up a key in an *association list:* a
 list of two-item lists. In each two-item list, the first is a *key* and
-the second is a *value.* The inputs are a key and an association list\index{dictionary}\index{association list};
+the second is a *value.* The inputs are a key and an association list{index}`dictionary`{index}`association list`;
 the block reports the first key-value pair whose key is equal to the
 input key.
 
-`For each item`\index{for each item block} is a variant of the primitive
-version that provides a \# variable\index{#@\texttt{\#} variable} containing the
+`For each item`{index}`for each item block` is a variant of the primitive
+version that provides a \# variable{index}`#@\texttt{\#` variable} containing the
 position in the input list of the currently considered item. `Multimap`
-\index{multimap block} is a version of `map` that allows multiple list
+{index}`multimap block` is a version of `map` that allows multiple list
 inputs, in which case the mapping function must take as many inputs as
 there are lists; it will be called with all the first items, all the
 second items, and so on. `Zip` takes any number of lists as inputs; it
 reports a list of lists: all the first items, all the second items, and
 so on. The `no-name` identity function reports its input.
 
-`Sentence`\index{sentence block@\texttt{sentence} block} and `sentence ➔ list`
-\index{sentence to list@\texttt{sentence ➔ list} block} are borrowed from the [word and sentence library](#word-and-sentence-library) to serve as a variant of append that accepts non-lists
+`Sentence`{index}`sentence block@\texttt{sentence` block} and `sentence ➔ list`
+{index}`sentence to list@\texttt{sentence ➔ list` block} are borrowed from the [word and sentence library](#word-and-sentence-library) to serve as a variant of append that accepts non-lists
 as inputs. `Printable` takes a list structure of any depth as input and
 reports a compact representation of the list as a text string.
 
@@ -1119,39 +1119,39 @@ blocks:
 ![image388.png](images/01-blocks-scripts-and-sprites/image388.png) <!-- {width=1.68889in height=4.75in} -->
 ![image389.png](images/01-blocks-scripts-and-sprites/image389.png) <!-- {width=1.04444in height=0.16111in} -->
 
-`Catch`\index{$catch$ block} and `throw`\index{$throw$ block} provide a nonlocal
+`Catch`{index}`$catch$ block` and `throw`{index}`$throw$ block` provide a nonlocal
 exit facility. You can drag the tag from a `catch` block to a `throw` inside
 its C-slot, and the throw will then jump directly out to the matching
 catch without doing anything in between.
 
-`If do and pause all`\index{$if do and pause all$ block} is for setting a
+`If do and pause all`{index}`$if do and pause all$ block` is for setting a
 breakpoint while debugging code. The idea is to put show variable blocks
 for local variables in the C-slot; the watchers will be deleted when the
 user continues from the pause.
 
-`Ignore`\index{$ignore$ block} is used when you need to call a reporter but
+`Ignore`{index}`$ignore$ block` is used when you need to call a reporter but
 you don’t care about the value it reports. (For example, you are writing
 a script to time how long the reporter takes.)
 
-The `cascade`\index{cascade blocks} blocks take an initial value and call
+The `cascade`{index}`cascade blocks` blocks take an initial value and call
 a function repeatedly on that value, *f*(*f*(*f*(*f*…(*x*)))).
 
-The `compose`\index{$compose$ block} block takes two functions and reports
+The `compose`{index}`$compose$ block` block takes two functions and reports
 the function *f*(*g*(*x*)).
 
 The first three repeat blocks
-\index{repeat blocks} are variants of the primitive `repeat until` block,
+{index}`repeat blocks` are variants of the primitive `repeat until` block,
 giving all four combinations of whether the first test happens before or
 after the first repetition, and whether the condition must be true or
 false to continue repeating. The last repeat block is like the `repeat`
 primitive, but makes the number of repetitions so far available to the
-repeated script. The next two blocks are variations on `for`\index{$for$
-block} : the first allows an explicit step instead of using ±1, and the
+repeated script. The next two blocks are variations on `for`{index}`$for$
+block` : the first allows an explicit step instead of using ±1, and the
 second allows any values, not just numbers; inside the script you say ![image390.png](images/01-blocks-scripts-and-sprites/image390.png){.image-inline} <!-- {width=3.15278in height=0.29861in} -->
 replacing the grey block in the picture with an expression to give the next
 desired value for the loop index.
 
-`Pipe`\index{pipe block@\texttt{pipe} block} allows reordering a nested composition with a left-to-right one:
+`Pipe`{index}`pipe block@\texttt{pipe` block} allows reordering a nested composition with a left-to-right one:
 
 ![image392.png](images/01-blocks-scripts-and-sprites/image392.png) <!--  style="width:3.70972in;height:1.17153in" alt="Macintosh HD:Users:bh:Desktop:untitled script pic (1).png" / --> ![image391.png](images/01-blocks-scripts-and-sprites/image391.png) <!--  style="width:3.44097in;height:1.36111in" alt="Macintosh HD:Users:bh:Desktop:untitled script pic (2).png" / -->
 
@@ -1159,31 +1159,31 @@ The {index}`stream library` has these blocks:
 
 ![image393.png](images/01-blocks-scripts-and-sprites/image393.png) <!-- {width=3.16111in height=2.15347in} -->
 
-*Streams*\index{stream list} are a special kind
+*Streams*{index}`stream list` are a special kind
 of list whose items are not computed until they are needed. This makes
 certain computations more efficient, and also allows the creation of
 lists with infinitely many items, such as a list of all the positive
 integers. The first five blocks are stream versions of the list blocks.
 
-`in front of`\index{in front of stream block}, `item 1 of`\index{item 1
-of stream block}, `all but first of`\index{all but first of stream
-block}, `map`\index{map over stream block}, and `keep`. `Show stream`
-\index{show stream block} takes a stream and a number as inputs, and
+`in front of`{index}`in front of stream block`, `item 1 of`{index}`item 1
+of stream block`, `all but first of`{index}`all but first of stream
+block`, `map`{index}`map over stream block`, and `keep`. `Show stream`
+{index}`show stream block` takes a stream and a number as inputs, and
 reports an ordinary list of the first *n* items of the stream. `Stream`
-\index{Stream block} is like the primitive list; it makes a finite
-stream from explicit items. `Sieve`\index{sieve block} is an example
+{index}`Stream block` is like the primitive list; it makes a finite
+stream from explicit items. `Sieve`{index}`sieve block` is an example
 block that takes as input the stream of integers starting with 2 and
 reports the stream of all the prime numbers. `Stream with numbers from` is
-\index{Stream with numbers from block} like the numbers from block for
+{index}`Stream with numbers from block` like the numbers from block for
 lists, except that there is no endpoint; it reports an infinite stream
 of numbers.
 
 <a name="word-and-sentence-library"></a>
-The **word and sentence library**\index{sentence library} has these blocks:
+The **word and sentence library**{index}`sentence library` has these blocks:
 
 <!-- TODO: Index Entries for all these blocks -->
 ![image394.png](images/01-blocks-scripts-and-sprites/image394.png)
-\index{$word ➔ list$ block}
+{index}`$word ➔ list$ block`
 
 This library has the goal of recreating the Logo approach to handling text:
 A text isn’t best viewed as a string of characters, but rather as a *sentence*, made of *words,*
@@ -1196,17 +1196,17 @@ you’re proof-reading. (Even then: Proofreading is *diffciult,* because
 you see what you expect to see, what will make the snetence make sense,
 rather than the misspelling in front of of your eyes.) Internally, Logo
 stores a sentence as a list of words, and a word as a string of letters.
-\index{all but first blocks}
+{index}`all but first blocks`
 
 Inexplicably, the designers of Scratch chose to abandon that tradition,
 and to focus on the representation of text as a string of characters.
 The one vestige of the {index}`Logo tradition` from which
-Scratch developed is the block named letter (1) of (world)\index{letter
-(1) of (world) block} , rather than character (1) of (world). {.snap}`Snap`
+Scratch developed is the block named letter (1) of (world){index}`letter
+(1) of (world) block` , rather than character (1) of (world). {.snap}`Snap`
 inherits its text handling from Scratch.
 
-In Logo, the visual representation of a sentence\index{visual
-representation of a sentence} (a list of words) looks like a natural
+In Logo, the visual representation of a sentence{index}`visual
+representation of a sentence` (a list of words) looks like a natural
 language sentence: a string of words with spaces between them. In
 {.snap}`Snap`, the visual representation of a list looks nothing at all like
 natural language. On the other hand, representing a sentence as a string
@@ -1232,10 +1232,10 @@ constructor) accepts any number of inputs, which can be words,
 sentences-as-lists, or sentences-as-strings. (If inputs are lists of
 lists, only one level of flattening is done.) `Sentence` reports a list of
 words; there will be no empty words or words containing spaces. The four
-blocks with right-arrows in their names\index{list ➔ sentence block}
+blocks with right-arrows in their names{index}`list ➔ sentence block`
 convert back and forth between text strings (words or sentences) and
 lists. (Splitting a word into a list of letters is unusual unless you’re
-a linguist investigating orthography.) `Printable`\index{printable block}
+a linguist investigating orthography.) `Printable`{index}`printable block`
 takes a list (including a deep list) of words as input and reports a
 text string in which parentheses are used to show the structure, as in
 Lisp/Scheme.
@@ -1248,15 +1248,15 @@ Costumes are first class data
 in {.snap}`Snap`. Most of the processing of costume data is done by primitive
 blocks in the Looks category. (See page
 [79](#media-computation-with-costumes).) This library provides snap
-\index{snap block}, which takes a picture using your computer’s camera
+{index}`snap block`, which takes a picture using your computer’s camera
 and reports it as a costume.
 
-The bar charts library\index{bar charts library} has these blocks:
+The bar charts library{index}`bar charts library` has these blocks:
 
 ![image396.png](images/01-blocks-scripts-and-sprites/image396.png) <!-- {width=3.43056in height=1.91667in} -->
 
-`Bar chart of table`\index{bar chart
-block} takes a table (typically from a CSV data set) as input and
+`Bar chart of table`{index}`bar chart
+block` takes a table (typically from a CSV data set) as input and
 reports a summary of the table grouped by the field in the specified
 column number. The remaining three inputs are used only if the field
 values are numbers, in which case they can be grouped into buckets
@@ -1271,7 +1271,7 @@ contains the bucket name or smallest number. The second column contains
 a nonnegative integer that says how many records in the input table fall
 into this bucket. The third column is a subtable containing the actual
 records from the original table that fall into the bucket. `Plot bar chart`
-\index{plot bar chart block} takes the table reported by bar chart
+{index}`plot bar chart block` takes the table reported by bar chart
 and graphs it on the stage, with axes labelled appropriately. The
 remaining blocks are helpers for those.
 
@@ -1279,20 +1279,20 @@ If your buckets aren't of constant width, or you want to group by some
 function of more than one field, load the "Frequency Distribution
 Analysis" library instead.
 
-The multi-branched conditional library\index{conditional
-library:multiple-branch} has these blocks:
+The multi-branched conditional library{index}`conditional
+library:multiple-branch` has these blocks:
 
 ![image397.png](images/01-blocks-scripts-and-sprites/image397.png) <!-- {width=1.85in height=2.47986in} -->
 
 The `catch` and `throw` blocks duplicate ones in the iteration library, and are
 included because they are used to implement the others. The `cases: if/then` block
-\index{cases block} sets up a multi-branch conditional, similar to cond
-in Lisp\index{cond in Lisp} or switch in C\index{switch in C} -family
+{index}`cases block` sets up a multi-branch conditional, similar to cond
+in Lisp{index}`cond in Lisp` or switch in C{index}`switch in C` -family
 languages. The first branch is built into the cases block; it consists
 of a Boolean test in the first hexagonal slot and an action script, in
 the C-slot, to be run if the test reports true. The remaining branches
 go in the variadic hexagonal input at the end; each branch consists of
-an `else if` block\index{else if block}, which includes the Boolean test
+an `else if` block{index}`else if block`, which includes the Boolean test
 and the corresponding action script, except possibly for the last
 branch, which can use the unconditional {index}`\`else\` block<`else` block>`.
 As in other languages, once a branch succeeds, no other branches are
@@ -1305,7 +1305,7 @@ The {index}`variadic library` has these blocks:
 ![image398.png](images/01-blocks-scripts-and-sprites/image398.png) <!-- {width=1.19653in height=0.41667in} -->
 
 :::{index}
-\index{sum block}\index{all of block}\index{any of block}
+{index}`sum block`{index}`all of block`{index}`any of block`
 :::
 These are versions of the associative
 operators `and`, and `or` that take any number of inputs
@@ -1319,11 +1319,11 @@ maximum are no longer included, because the primitive operators `+` `x`,
 The colors and {index}`crayons library` has these blocks:
 
 It is intended as a more powerful replacement for the primitive `set pen`
-block\index{set pen block}, including *first class color* support; `HSL color`\index{HSL color} specification as a better alternative to the HSV
+block{index}`set pen block`, including *first class color* support; `HSL color`{index}`HSL color` specification as a better alternative to the HSV
 that {.snap}`Snap` inherits from JavaScript; a “{index}`fair hue`”
 scale that compensates for the eye’s grouping a wide range of light
 frequencies as green while labelling mere slivers as orange or yellow;
-the `X11/W3C standard color names`\index{X11/W3C color names}; `RGB in
+the `X11/W3C standard color names`{index}`X11/W3C color names`; `RGB in
 hexadecimal`; a linear color scale (as in the old days, but better) based
 on fair hues and including shades (darker colors) and grayscale. Another
 linear scale is a curated set of 100 “crayons,” explained further on the
@@ -1333,19 +1333,19 @@ next page.
 
 Colors are
 created by the ![image414.png](images/01-blocks-scripts-and-sprites/image414.png){.image-inline} <!--  style="width:0.95in;height:0.225in" alt="Macintosh HD:Users:bh:Desktop:color picker.png" / --> block (for direct user selection), the `color from`
-\index{color from block} to specify a color numerically,  or by ![image413.png](images/01-blocks-scripts-and-sprites/image413.png){.image-inline} <!--  style="width:1.13333in;height:0.23333in" alt="Macintosh HD:Users:bh:Desktop:pen-color.png" / --> , which
+{index}`color from block` to specify a color numerically,  or by ![image413.png](images/01-blocks-scripts-and-sprites/image413.png){.image-inline} <!--  style="width:1.13333in;height:0.23333in" alt="Macintosh HD:Users:bh:Desktop:pen-color.png" / --> , which
 reports the color currently in use by the pen. The `from color` block
-\index{from color block} reports names or numbers associated with a
+{index}`from color block` reports names or numbers associated with a
 color:
 
 ![image411.png](images/01-blocks-scripts-and-sprites/image411.png){.image-4x} <!--  style="width:0.95in;height:0.225in" alt="Macintosh HD:Users:bh:Desktop:color picker.png" / -->
 
 Colors can be created from
-other colors:\index{mix colors block}
+other colors:{index}`mix colors block`
 ![image415.png](images/01-blocks-scripts-and-sprites/image415.png) <!-- {width=4.83333in height=0.43056in} -->
 
 The three blocks with pen in their names are improved versions of
-primitive Pen blocks. In principle `set pen`\index{set pen block}, for
+primitive Pen blocks. In principle `set pen`{index}`set pen block`, for
 example, could be implemented using a (hypothetical) `set pen` to color
 composed with the `color from` block, but in fact `set pen` benefits from
 knowing how the pen color was set in its previous invocation, so it’s
@@ -1378,7 +1378,7 @@ Here is the color number scale:
 hue scale.)
 
  And
-here are the 100 crayons\index{crayons} :
+here are the 100 crayons{index}`crayons` :
 
 ![image417.png](images/01-blocks-scripts-and-sprites/image417.png) <!-- {width=5in height=0.20833in} -->
 
@@ -1397,7 +1397,7 @@ There are many scales:
 ![image427.png](images/01-blocks-scripts-and-sprites/image427.png) <!-- {width=4.29167in height=1.90972in} -->
 
 The white slot at the end of some of the blocks has two purposes. It can
-be used to add a transparency\index{transparency} to a color (0=opaque,
+be used to add a transparency{index}`transparency` to a color (0=opaque,
 100=transparent):
 
 ![image428.png](images/01-blocks-scripts-and-sprites/image428.png) <!-- {width=4.29167in height=1.90972in} -->
@@ -1415,7 +1415,7 @@ equivalent:
 
 `Set pen crayon to` provides the equivalent of a box of 100 crayons. They
 are divided into color groups, so the menu in the set pen crayon to
-input\index{set pen to crayon block} slot has submenus. The colors are
+input{index}`set pen to crayon block` slot has submenus. The colors are
 chosen so that starting
 from crayon 0, `change pen crayon by` 10 rotates through an interesting,
 basic set of ten colors:
@@ -1436,17 +1436,17 @@ stage background color. White is crayon 14.) Note that crayon 43 is
 
 See Appendix A (@sec-crayons-and-color-numbers) for more information.
 
-The **crayon library**\index{crayon library} has only the crayon features,
+The **crayon library**{index}`crayon library` has only the crayon features,
 without the rest of the colors package.
 
 ![image442.png](images/01-blocks-scripts-and-sprites/image442.png)
 
-The catch errors library\index{catch errors library} has these blocks:
+The catch errors library{index}`catch errors library` has these blocks:
 
 ![image444.png](images/01-blocks-scripts-and-sprites/image444.png)
 
 The `safely try` block
-\index{safely try block} allows you to handle errors that happen when
+{index}`safely try block` allows you to handle errors that happen when
 your program is run within the program, instead of stopping the script
 with a red halo and an obscure error message. The block runs the script
 in its first C-slot. If it finishes without an error, nothing else
@@ -1457,20 +1457,20 @@ the error. The {index}`\`error\` block<`error` block>` is sort of the opposite:
 it lets your program *generate* an error message, which will be
 displayed with a red halo unless it is caught by `safely try`. `Safely try reporting` is the reporter version of `safely try`.
 
-The text costumes library\index{text costume library} has only two
+The text costumes library{index}`text costume library` has only two
 blocks:
 
  ![image446.png](images/01-blocks-scripts-and-sprites/image446.png) <!--  style="width:1.92in;height:0.45078in" alt="Macintosh HD:Users:bh:Desktop:textcostume.png" / -->
  ![image447.png](images/01-blocks-scripts-and-sprites/image447.png){.image-4x} <!-- {width=3.25972in height=0.18958in} -->
 
 `Costume from text`
-reports a costume\index{costume from text block} that can be used with
+reports a costume{index}`costume from text block` that can be used with
 the `switch to costume` block to make a
 button:
 
 ![image445.png](images/01-blocks-scripts-and-sprites/image445.png) <!--  style="width:0.53472in;height:0.20833in" alt="Macintosh HD:Users:bh:Desktop:Snaplabel.png" / -->
 
-`Costume with background`\index{costume with background block} reports a
+`Costume with background`{index}`costume with background block` reports a
 costume made from another costume by coloring its background, taking a
 color input like the `set pen color to RGB(A)` block and a number of
 turtle steps of padding around the original costume. These two blocks
@@ -1478,14 +1478,14 @@ work together to make even better buttons:
 
 ![image448.png](images/01-blocks-scripts-and-sprites/image448.png) <!-- {width=5.51in height=0.68in} -->
 
-The text to speech library\index{speech synthesis library} has these
+The text to speech library{index}`speech synthesis library` has these
 blocks:
 
 ![image449.png](images/01-blocks-scripts-and-sprites/image449.png) <!--  style="width:2.275in;height:0.8in" alt="Macintosh HD:Users:bh:Desktop:speechlib.png" / -->
 
 This library
 interfaces with a capability in up-to-date browsers, so it might not
-work for you.\index{speak block} It works best if the accent matches
+work for you.{index}`speak block` It works best if the accent matches
 the text!
 
 The {index}`parallelization library` contains
@@ -1494,13 +1494,13 @@ these blocks:
 ![image450.png](images/01-blocks-scripts-and-sprites/image450.png) <!-- {width=1.17986in height=1.25972in} -->
 
 The two `do in parallel`blocks
-\index{do in parallel block} take any number of scripts as inputs.
+{index}`do in parallel block` take any number of scripts as inputs.
 Those scripts will be run in parallel, like ordinary independent scripts
 in the scripting area. `The do in parallel and wait` version waits until all of those
 scripts have finished before continuing the script below the block.
 
 The create variables library
-\index{variables library} has these blocks:\index{does var exist block}
+{index}`variables library` has these blocks:{index}`does var exist block`
 
 ![image451.png](images/01-blocks-scripts-and-sprites/image451.png) <!-- {width=1.37778in height=1.48333in} -->
 
@@ -1510,17 +1510,17 @@ the program to compute the variable name(s). It can also set and find
 the values of these variables, show and hide their stage watchers,
 delete them, and find out if they already exist.
 
-The getters and setters library\index{getter/setter library} has these
+The getters and setters library{index}`getter/setter library` has these
 blocks:
 
 ![image452.png](images/01-blocks-scripts-and-sprites/image452.png) <!-- {width=1.875in height=1.05in} -->
 
 The purpose of this library
 is to allow program access to the settings controlled by user interface
-elements, such as the settings menu ![image453.png](images/01-blocks-scripts-and-sprites/image453.png). The `setting` block\index{setting
-block} reports a setting; the `set flag` block\index{set flag block} sets
+elements, such as the settings menu ![image453.png](images/01-blocks-scripts-and-sprites/image453.png). The `setting` block{index}`setting
+block` reports a setting; the `set flag` block{index}`set flag block` sets
 yes-or-no options that have checkboxes in the user interface, while the
-`set value` block\index{set value block} controls settings with numeric
+`set value` block{index}`set value block` controls settings with numeric
 or text values, such as project name.
 
 Certain settings are ordinarily remembered on a per-user basis, such as
@@ -1530,23 +1530,23 @@ library is loaded. No permanent changes are made. Note: this library has
 not been converted for version 7.0, so you’ll have to enable Javascript
 extensions to use it.
 
-The bignums, rationals, complex \#s library\index{infinite precision
-integer library}\index{library!infinite precision integers} has these blocks:
+The bignums, rationals, complex \#s library{index}`infinite precision
+integer library`{index}`library!infinite precision integers` has these blocks:
 
 ![image454.png](images/01-blocks-scripts-and-sprites/image454.png)
 
-The `USE BIGNUMS` block\index{BIGNUMS block} takes a Boolean input, to turn
+The `USE BIGNUMS` block{index}`BIGNUMS block` takes a Boolean input, to turn
 the infinite precision feature on or off. When on, all of the arithmetic
 operators are redefined to accept and report integers of any number of
 digits (limited only by the memory of your computer) and, in fact, the
 entire Scheme numeric tower, with exact rationals and with complex
-numbers. The `Scheme number` block\index{Scheme number block} has a list
+numbers. The `Scheme number` block{index}`Scheme number block` has a list
 of functions applicable to Scheme numbers, including subtype predicates
 such as rational? and infinite?, and selectors such as numerator and
 real-part.
 
-<!-- I cannot figure out an index format that compiles this...\index{"\! block"@\texttt{\!} block}  -->
-The `!` block computes the factorial function\index{factorial}, useful to test whether bignums are turned on. Without bignums:
+<!-- I cannot figure out an index format that compiles this...{index}`"\! block"@\texttt{\!` block}  -->
+The `!` block computes the factorial function{index}`factorial`, useful to test whether bignums are turned on. Without bignums:
 
 ![image455.png](images/01-blocks-scripts-and-sprites/image455.png) <!-- {width=0.29167in height=0.16667in} -->
 
@@ -1559,12 +1559,12 @@ right-click on the block and choose “result pic,” you can open the
 resulting picture in a browser window and scroll through it. (These
 values end with a bunch of zero digits. That’s not roundoff error; the
 prime factors of 100! and 200! include many copies of 2 and 5.) The
-block with no name\index{block with no name} is a way to enter things
+block with no name{index}`block with no name` is a way to enter things
 like 3/4 and 4+7i into numeric input slots by converting the slot to Any
 type.
 
-The strings, multi-line input library\index{string processing library}
-provides these blocks:\index{case-independent comparisons block}
+The strings, multi-line input library{index}`string processing library`
+provides these blocks:{index}`case-independent comparisons block`
 
 ![image463.png](images/01-blocks-scripts-and-sprites/image463.png) <!-- {width=3.9375in height=2.04167in} -->
 
@@ -1584,7 +1584,7 @@ Despite the name, this isn’t only about graphics; you can animate the values
 of a variable, or anything else that’s expressed numerically.
 
 
-The central idea of this library is an *easing function*\index{easing function} *,* a
+The central idea of this library is an *easing function*{index}`easing function` *,* a
 reporter whose domain and range are real numbers between 0 and 1
 inclusive. The function represents what fraction of the “distance” (in
 quotes because it might be any numeric value, such as temperature in a
@@ -1598,7 +1598,7 @@ slowly and accelerating. (Note that, since it’s a requirement that
 The two Motion blocks in this library animate a sprite. `Glide` always animates
 the sprite’s motion. `Animate's` first pulldown menu input allows you to
 animate horizontal or vertical motion, but will also animate the
-sprite’s direction or size. The `animate setter` block\index{animate block} in
+sprite’s direction or size. The `animate setter` block{index}`animate block` in
 Control lets you animate any numeric quantity with any easing function.
 The getter and setter inputs are best explained by example:
 
@@ -1610,7 +1610,7 @@ is equivalent to
 
 The other blocks in the library are helpers for these four.
 
-The serial ports library\index{serial-ports library} contains these
+The serial ports library{index}`serial-ports library` contains these
 blocks:
 
 ![image468.png](images/01-blocks-scripts-and-sprites/image468.png) <!--  style="width:1.73264in;height:1.03472in" -->
@@ -1620,20 +1620,20 @@ is used to allow hardware developers to control devices such as robots
 that are
 connected to your computer via a serial port.
 
-The frequency distribution analysis library\index{frequency
-distribution analysis library} has these blocks:
+The frequency distribution analysis library{index}`frequency
+distribution analysis library` has these blocks:
 
 ![image469.png](images/01-blocks-scripts-and-sprites/image469.png) <!-- {width=4.02708in height=2.39583in} -->
 
 This is a collection of tools for analyzing large data sets and plotting
-histogram\index{histogram} s of how often some value is found in some
+histogram{index}`histogram` s of how often some value is found in some
 column of the table holding the data.
 
 For more information go here:
 
 https://tinyurl.com/jens-data
 
-The audio comp library\index{sound manipulation library} includes these
+The audio comp library{index}`sound manipulation library` includes these
 blocks:
 
 ![image470.png](images/01-blocks-scripts-and-sprites/image470.png) <!-- {width=3.54167in height=2.98125in} -->
@@ -1643,10 +1643,10 @@ one that you record or one from our collection of sounds, and
 manipulates it by systematically changing the intensity of the samples
 in the sound and by changing the sampling rate at which the sound is
 reproduced. Many of the blocks are helpers for the `plot sound` block,
-used to plot the waveform of a sound\index{plot sound block}. The `play sound` (primitive) block\index{play block} plays a sound. \_\_ `Hz for`
-\index{Hz for block} reports a sine wave as a list of samples.
+used to plot the waveform of a sound{index}`plot sound block`. The `play sound` (primitive) block{index}`play block` plays a sound. \_\_ `Hz for`
+{index}`Hz for block` reports a sine wave as a list of samples.
 
-The web services library\index{web services library} has these blocks:
+The web services library{index}`web services library` has these blocks:
 
 ![image471.png](images/01-blocks-scripts-and-sprites/image471.png)
 
@@ -1654,13 +1654,13 @@ The first block is a generalization of the primitive
 {index}`\`url\` block<`url` block>` , allowing more control over the various
 options in web requests:
 `GET`, `POST`, `PUT`, and `DELETE`, and fine control over the content of the
-message sent to the server. `Current location`\index{current location
-block} reports your latitude and longitude. `Listify`\index{listify
-block} takes some text in JSON format (see page
+message sent to the server. `Current location`{index}`current location
+block` reports your latitude and longitude. `Listify`{index}`listify
+block` takes some text in JSON format (see page
 [54](#multi-dimensional-lists-and-json)) and converts it to a structured
-list. `Value at key`\index{value at key block} looks up a key-value pair
+list. `Value at key`{index}`value at key block` looks up a key-value pair
 in a (listified) JSON dictionary. The `key:value:` block
-\index{$key:value:$ block} is just a constructor for an abstract data
+{index}`$key:value:$ block` is just a constructor for an abstract data
 type used with the other blocks
 
 The {index}`database library` contains these blocks:
@@ -1702,7 +1702,7 @@ The APL primitives {index}`library contains` these blocks:
 
 For more information about APL, see @sec-appendix-b-apl).
 
-The  **list comprehension library**\index{list comprehension library} has one block, `zip`:
+The  **list comprehension library**{index}`list comprehension library` has one block, `zip`:
 
 ![image476.png](images/01-blocks-scripts-and-sprites/image476.png)
 
@@ -1716,7 +1716,7 @@ The Number-type inputs specify the leaf dimension for each tree, so the
 function input might be called with a vector from the first tree and an
 atom from the second tree.
 
-The **bitwise library**\index{bitwise library} provides bitwise
+The **bitwise library**{index}`bitwise library` provides bitwise
 logic functions; each bit of
 the reported value is the result of applying the corresponding Boolean
 function to the corresponding bits of the input(s). The Boolean
@@ -1729,26 +1729,26 @@ don’t already know what these mean, find a tutorial online.
 
 ![image477.png](images/01-blocks-scripts-and-sprites/image477.png)
 
-The **MQTT library**\index{MQTT library} supports the Message Queuing
+The **MQTT library**{index}`MQTT library` supports the Message Queuing
 Telemetry Transport protocol, for connecting with IOT devices. See
 <https://mqtt.org/> for more information.
 
 ![image487.png](images/01-blocks-scripts-and-sprites/image487.png)
 
-The **Signada library**\index{Signada library} allows you to control a
+The **Signada library**{index}`Signada library` allows you to control a
 microBit or similar device that works with the Signada MicroBlocks
 project.
 
 ![image488.png](images/01-blocks-scripts-and-sprites/image488.png)
 
-The **menus library**\index{menus library} provides the ability to
+The **menus library**{index}`menus library` provides the ability to
 display hierarchical menus on the stage, using the ask block’s ability
 to take lists as inputs. See @sec-ask-lists.
 
 ![image486.png](images/01-blocks-scripts-and-sprites/image486.png)
 
-The **Sci{.snap}`Snap` library**\index{SciSnap@"SciSnap! library"} and the **TuneScope
-library**\index{TuneScope@"TuneScope library"} are too big to discuss here and are
+The **Sci{.snap}`Snap` library**{index}`SciSnap@"SciSnap! library"` and the **TuneScope
+library**{index}`TuneScope@"TuneScope library"` are too big to discuss here and are
 documented separately at
 <http://emu-online.de/ProgrammingWithSciSnap.pdf> and
 <https://maketolearn.org/creating-art-animations-and-music/>

--- a/02-saving-and-loading-projects-and/index.md
+++ b/02-saving-and-loading-projects-and/index.md
@@ -1,4 +1,5 @@
-# Saving and Loading Projects and Media {#sec-ch02}
+(sec-ch02)=
+# Saving and Loading Projects and Media
 
 After you’ve created a project, you’ll want to save it, so that you can
 have access to it the next time you use {.snap}`Snap`. There are two ways to
@@ -21,6 +22,7 @@ be the only usable option.) The text box at the bottom right of the Save
 dialog allows you to enter project notes that are saved with the
 project.
 
+(sec-local-storage)=
 ## Local Storage
 
 Click on Computer and {.snap}`Snap`’s Save Project dialog window will be
@@ -29,6 +31,7 @@ project has a name, that name will be the default filename if you don’t
 give a different name. Another, equivalent way to save to disk is to
 choose "`Export project`" from the File menu.
 
+(sec-creating-cloud-account)=
 ## Creating a {index}`Cloud Account`
 
 The other possibility is to
@@ -76,6 +79,7 @@ go wrong; since {.snap}`Snap` runs in JavaScript in your browser, it is
 strongly isolated from the rest of your computer. But the lawyers make
 us say this.)
 
+(sec-saving-to-cloud)=
 ## Saving to the Cloud
 
 Once you’ve created your account, you can log into it using the "`Login…`"
@@ -96,6 +100,7 @@ optionally project notes; your project will be saved online and can be
 loaded from anywhere with net access. The project notes will be visible
 to other users if you publish your project.
 
+(sec-loading-saved-projects)=
 ## Loading Saved Projects{index}`loading saved projects`
 
 Once you’ve saved a project, you want to be able to load it back into
@@ -129,6 +134,7 @@ If you saved projects in an earlier version of {.snap}`Snap` using the
 to allow you to retrieve those projects. But you can save them only with
 the Computer and Cloud options.
 
+(sec-lose-project)=
 ## If you lose your project, do this first!
 
 If you are still in **{.snap}`Snap`** and realize that you’ve loaded another
@@ -158,6 +164,7 @@ left of the project name on the toolbar at the top of the window:
 <!-- TODO: MISSING FILE -->
 <!-- ![image391.png](assets/image391.png)  style="width:0.31944in;height:0.18056in"/  -->
 
+(sec-private-public-projects)=
 ## Private and Public Projects
 
 By default, a project you save in the cloud is private; only you can see

--- a/02-saving-and-loading-projects-and/index.md
+++ b/02-saving-and-loading-projects-and/index.md
@@ -32,7 +32,7 @@ choose "`Export project`" from the File menu.
 ## Creating a {index}`Cloud Account`
 
 The other possibility is to
-save your project "`in the cloud`",\index{save your project in the cloud}
+save your project "`in the cloud`",{index}`save your project in the cloud`
 at the {.snap}`Snap` web site. In order to do this, you need an account with
 us. Click on the {index}`Cloud button` (![image489.png](assets/image489.png) <!--  style="width:0.29167in;height:0.16667in" / --> ) in the Tool Bar.
 Choose the “`Signup…`” option. This will show you a window that looks like
@@ -67,8 +67,8 @@ marketing emails of any kind through this site, neither from us nor from
 third parties. If, nevertheless, you are worried about providing this
 information, do a web search for “temporary email.”
 
-Finally, you must read and agree to the Terms of Service\index{Terms of
-Service}. A quick summary: Don’t interfere with anyone else’s use of
+Finally, you must read and agree to the Terms of Service{index}`Terms of
+Service`. A quick summary: Don’t interfere with anyone else’s use of
 the web site, and don’t put copyrighted media or personally identifiable
 information in projects that you share with other users. And we’re not
 responsible if something goes wrong. (Not that we *expect* anything to
@@ -96,7 +96,7 @@ optionally project notes; your project will be saved online and can be
 loaded from anywhere with net access. The project notes will be visible
 to other users if you publish your project.
 
-## Loading Saved Projects\index{loading saved projects}
+## Loading Saved Projects{index}`loading saved projects`
 
 Once you’ve saved a project, you want to be able to load it back into
 {.snap}`Snap`. There are two ways to do this:
@@ -134,7 +134,7 @@ the Computer and Cloud options.
 If you are still in **{.snap}`Snap`** and realize that you’ve loaded another
 project without saving the one you were working on: ***Don’t edit the
 new project.*** From the File menu ![image384.png](assets/image384.png) <!--  style="width:0.31944in;height:0.18056in" alt="Macintosh HD:Users:bh:Desktop:Dropbox:manual (1):filebutton.png" / --> choose the "`Restore unsaved project`"
-option\index{Restore unsaved project option}.
+option{index}`Restore unsaved project option`.
 
 Restore unsaved project will also work if you log out of {.snap}`Snap` and
 later log back in, as long as you don’t edit another project meanwhile.

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -3,9 +3,22 @@
 <!-- Editor Note: This document should be written using GitHub-flavored markdown,
   unlike the rest of the manual. -->
 
+This manual is written in **MyST Markdown** (Markedly Structured Text) for **JupyterBook 2**.
+
+## JupyterBook 2 / MyST Documentation
+
+**Official Documentation:**
+* [MyST Markdown Guide](https://mystmd.org/guide) - Main MyST documentation
+* [MyST Syntax Reference](https://mystmd.org/guide/syntax) - Complete syntax guide
+* [JupyterBook Documentation](https://jupyterbook.org/) - Book theme and features
+* [MyST Directives](https://mystmd.org/guide/directives) - Special content blocks
+* [Cross-references](https://mystmd.org/guide/cross-references) - Linking sections and figures
+
+## Core Syntax Rules
+
 * Write UI elements inside quoted code blocks. e.g. ```"`Open`"```
 * Monospaced text should use the CSS class `.mono` e.g. `[text here]{.mono}`
-* Do not put spaces around index entries. `text\index{text},`
+* Do not put spaces around index entries. `text{index}`text`,`
 * To write Snap! as stylized text write: `{.snap}`Snap``
 * Chapters are included at the top level of the repo, named 'NN-chapter'
   * Each contains an `index.md` file, which is the chapter's main content.
@@ -16,10 +29,28 @@
   * `blocks/help/` is the help screen for each block, named `selector.png`.
 
 
-## Editing Section References
+## Section Labels and Cross-References
 
-* Replace original text with a markdown link (e.g. `[text](url)`) with the section name but no page number
-* Links should be formatted like the URL, e.g. `../chapter-name`
+MyST uses labels to enable cross-references between sections.
+
+**Creating section labels:**
+```md
+(label-name)=
+# Section Title
+```
+
+**Referencing sections:**
+* Use `@label-name` to reference a labeled section
+* Example: `See @sec-ch01 for more information`
+
+**Label naming conventions:**
+* Chapter labels: `(sec-chNN)=` where NN is the chapter number
+* Section labels: `(sec-descriptive-name)=` using lowercase with hyphens
+* Figure labels: `{#fig-descriptive-name}` in image attributes
+
+**Links vs Cross-references:**
+* Use `@label` for internal cross-references (preferred for sections/figures)
+* Use `[text](url)` for external links or when you need custom link text
 
 ## Images
 
@@ -44,17 +75,39 @@ Write markdown like this:
 
 ## Indexing and Index Entries
 
-https://en.wikibooks.org/wiki/LaTeX/Indexing
+**MyST/JupyterBook 2 Syntax:** Use `{index}` with backticks instead of LaTeX `\index{}`.
 
-* Write an index entry by writing `text\index{text},` at the end of a term.
-* Do not put spaces around the `\index{}` command.
-* Use *LaTeX* inside the `\index` command.
-* `!` denotes sub-terms in the index.
-* Use `""` to escape special characters in the index.
-* Use `$$` for verabatim text in the index, mostly for block names.
-* The format is `\index{sortkey@entrytext}`
-  * You will need to use this when you are trying to index a block name.
-  * e.g. `\index{block name@$Block Name$ block}`
+**Basic index entries:**
+```md
+term{index}`term`
+```
+
+**Index with different display text:**
+```md
+{index}`display text<actual index term>`
+```
+
+**Sub-entries (using `!`):**
+```md
+{index}`main term!sub-term`
+```
+
+**Example:**
+```md
+The palette{index}`palette` area contains blocks{index}`block`.
+A hat block{index}`block!hat` starts a script.
+The {index}`green flag<single: flag, green>` starts the program.
+```
+
+**Special characters and formatting:**
+* `!` denotes sub-terms in the index (same as LaTeX)
+* Use `<>` angle brackets for alternate index text
+* Use `single:` for specialized index entries
+* For block names, use the block selector as the term
+
+**Additional Resources:**
+* [MyST Index Syntax](https://mystmd.org/guide/index-entries) - Official MyST index documentation
+* [LaTeX Indexing](https://en.wikibooks.org/wiki/LaTeX/Indexing) - Traditional reference (for understanding concepts)
 
 ## Making new CSS classes
 
@@ -63,11 +116,11 @@ Add all CSS to the file `snap-manual.scss`. All "image" related CSS should be pr
 * If you need to make classes for a specific chapter include that, e.g. `image-ch3-...`
 * Otherwise you can use `{style="..."}` to manually set the style of a single image
 
-## Callouts
-https://quarto.org/docs/authoring/callouts.html
+## Callouts and Admonitions
 
-You may want to replace images on text with a callout block.
+MyST supports callouts (admonitions) for highlighting special content.
 
+**Syntax:**
 ```md
 ::: {.callout-tip}
 ## Tip with Title
@@ -75,6 +128,66 @@ You may want to replace images on text with a callout block.
 This is an example of a callout with a title.
 :::
 ```
+
+**Available callout types:**
+* `.callout-note` - General notes and information
+* `.callout-tip` - Helpful tips and pro-tips
+* `.callout-warning` - Warnings and cautions
+* `.callout-important` - Important information
+* `.callout-caution` - Caution notices
+
+**Documentation:**
+* [MyST Admonitions](https://mystmd.org/guide/admonitions) - Official MyST docs
+* [Quarto Callouts](https://quarto.org/docs/authoring/callouts.html) - Similar syntax (for reference)
+
+## MyST Directives and Special Blocks
+
+MyST provides special directives for advanced formatting.
+
+**Subfigures** - Multiple images in one figure:
+```md
+```{subfigure} figure-id
+:gap: 1em
+:name: fig-figure-name
+
+![](image1.png)
+![](image2.png)
+```
+```
+
+**Multi-column layouts:**
+```md
+::: {.evenly-spaced-images layout-ncol=2}
+![](image1.png)
+![](image2.png)
+:::
+```
+
+**Other useful directives:**
+* Custom divs: `::: {.class-name}` for styled sections
+* Code blocks: ` ```{code-cell}` ` for executable code
+* Math: ` ```{math}` ` for block equations
+
+**Documentation:**
+* [MyST Directives](https://mystmd.org/guide/directives) - Complete directive reference
+* [MyST Figures](https://mystmd.org/guide/figures) - Figure and subfigure syntax
+
+## Building the Manual
+
+**Build HTML:**
+```bash
+myst build --html
+```
+
+**Build PDF:**
+```bash
+myst build --pdf
+```
+
+**Configuration files:**
+* `myst.yml` - Project configuration, metadata, and export settings
+* `toc.yml` - Table of contents structure
+* `_support/styles/snap-manual.scss` - Custom styles
 
 ---
 


### PR DESCRIPTION
## Convert Chapters 1 & 2 from Quarto to JupyterBook 2 (MyST)

Migrates chapters 1 and 2 of the Snap! manual from Quarto/LaTeX syntax to MyST Markdown format for JupyterBook 2, and updates the STYLEGUIDE to document the new conventions.

## Changes

**Chapter 1** (`01-blocks-scripts-and-sprites.md`)
- Converts 213 LaTeX `\index{term}` entries to MyST `{index}\`term\`` syntax
- Preserves advanced index features: sub-entries (`block!hat`), alternate display text (`<single: flag, green>`), and multi-level indexing

**Chapter 2** (`02-saving-and-loading-projects-and/index.md`)
- Converts remaining LaTeX `\index{}` entries to MyST syntax
- Replaces Quarto-style heading ID `{#sec-ch02}` with MyST label `(sec-ch02)=`
- Adds MyST section labels for all 6 subsections (`sec-local-storage`, `sec-creating-cloud-account`, `sec-saving-to-cloud`, `sec-loading-saved-projects`, `sec-lose-project`, `sec-private-public-projects`)

**STYLEGUIDE** (`STYLEGUIDE.md`)
- Adds links to official MyST and JupyterBook 2 documentation
- Documents MyST label/cross-reference syntax (`(label)=` and `@label`)
- Updates index entry documentation from LaTeX to MyST format
- Adds sections covering MyST directives, callouts/admonitions, subfigures, multi-column layouts, and build instructions (`myst build --html` / `--pdf`)

## Reviewer Notes

- Chapter 2 has a known missing image (`image391.png`) left as a TODO comment — this is pre-existing and not introduced by this PR
- Chapter 1 remains at the repo root as a flat file while chapters 2+ use a folder/`index.md` structure; this inconsistency is pre-existing and should be addressed separately

---

[Superconductor Ticket Implementation](https://www.superconductor.com/tickets/9TqrmM7tqKnb/implementations/KDCmmbb8NGMC) | [Guided Review](https://www.superconductor.com/tickets/9TqrmM7tqKnb/implementations/KDCmmbb8NGMC?tab=guided_review)

<!-- created-by-superconductor -->