### PR TITLE
Review Quarto to JupyterBook 2 conversion of Chapter 1 and draft Chapter 2

### DIFF
--- a/01-blocks-scripts-and-sprites.md
+++ b/01-blocks-scripts-and-sprites.md
@@ -107,46 +107,81 @@ shape is a special kind of input slot that accepts a *script* as the
 input.
 
 <!-- TODO-mb: These images are a bit small on the web. -->
-::: {.evenly-spaced-images layout-ncol=4}
+::::{grid} 4
+:class: evenly-spaced-images
+:gutter: 2
+
+:::{grid-item}
 In the sample script
-
-![image6.png](images/01-blocks-scripts-and-sprites/image6.png)
-
-the `repeat` block has two inputs: the number 4 and the script
-
-![image11.png](images/01-blocks-scripts-and-sprites/image11.png)
-
 :::
+
+:::{grid-item}
+![image6.png](images/01-blocks-scripts-and-sprites/image6.png)
+:::
+
+:::{grid-item}
+the `repeat` block has two inputs: the number 4 and the script
+:::
+
+:::{grid-item}
+![image11.png](images/01-blocks-scripts-and-sprites/image11.png)
+:::
+
+::::
 
 C-shaped blocks can be put in a script in two ways. If you see a white
 line and let go, the block will be inserted into the script like any
 command block:
 
-::: {.evenly-spaced-images layout-ncol=2}
-![image12.png](images/01-blocks-scripts-and-sprites/image12.png)
+::::{grid} 2
+:class: evenly-spaced-images
+:gutter: 2
 
+:::{grid-item}
+![image12.png](images/01-blocks-scripts-and-sprites/image12.png)
+:::
+
+:::{grid-item}
 ![image13.png](images/01-blocks-scripts-and-sprites/image13.png)
 :::
+
+::::
 
 <!-- Note until images are cleaned up 12 and 14 were identical, 13 and 15 were identical. -->
 
 But if you see an orange halo and let go, the block will *wrap* around
 the haloed blocks:
 
-::: {.evenly-spaced-images layout-ncol=2}
-![image16.png](images/01-blocks-scripts-and-sprites/image16.png)
+::::{grid} 2
+:class: evenly-spaced-images
+:gutter: 2
 
+:::{grid-item}
+![image16.png](images/01-blocks-scripts-and-sprites/image16.png)
+:::
+
+:::{grid-item}
 ![image17.png](images/01-blocks-scripts-and-sprites/image17.png)
 :::
+
+::::
 
 The halo will always extend from the cursor position to the bottom of
 the script:
 
-::: {.evenly-spaced-images layout-ncol=2}
-![image18.png](images/01-blocks-scripts-and-sprites/image18.png)
+::::{grid} 2
+:class: evenly-spaced-images
+:gutter: 2
 
+:::{grid-item}
+![image18.png](images/01-blocks-scripts-and-sprites/image18.png)
+:::
+
+:::{grid-item}
 ![image19.png](images/01-blocks-scripts-and-sprites/image19.png)
 :::
+
+::::
 
 If you want only some of those blocks, after wrapping you can grab the
 first block you don’t want wrapped, pull it down, and snap it under the
@@ -172,11 +207,19 @@ sprite in the scripting area, click on the picture of that sprite in the
 window. Try putting one of the following scripts in each sprite’s
 scripting area:
 
-::: {.evenly-spaced-images layout-ncol=2}
-![image26.png](images/01-blocks-scripts-and-sprites/image26.png)
+::::{grid} 2
+:class: evenly-spaced-images
+:gutter: 2
 
+:::{grid-item}
+![image26.png](images/01-blocks-scripts-and-sprites/image26.png)
+:::
+
+:::{grid-item}
 ![image27.png](images/01-blocks-scripts-and-sprites/image27.png)
 :::
+
+::::
 
 When you click the green flag, you should see one sprite rotate while
 the other moves back and forth. This experiment illustrates the way
@@ -184,11 +227,19 @@ different scripts can run in parallel. The turning and the moving happen
 together. Parallelism\index{parallelism} can be seen with multiple
 scripts of a single sprite also. Try this example:
 
-::: {.evenly-spaced-images layout-ncol=2}
-![image28.png](images/01-blocks-scripts-and-sprites/image28.png)
+::::{grid} 2
+:class: evenly-spaced-images
+:gutter: 2
 
+:::{grid-item}
+![image28.png](images/01-blocks-scripts-and-sprites/image28.png)
+:::
+
+:::{grid-item}
 ![image29.png](images/01-blocks-scripts-and-sprites/image29.png)
 :::
+
+::::
 
 When you click the green flag, the sprite should move back and forth
 
@@ -252,16 +303,28 @@ more interesting program, though, the sprites on stage will *interact*
 to tell a story, play a game, etc. Often one sprite will have to tell
 another sprite to run a script. Here’s a simple example:
 
-::: {#fig-broadcast-dog .evenly-spaced-images layout-ncol=4}
+::::{grid} 4
+:name: fig-broadcast-dog
+:class: evenly-spaced-images
+:gutter: 2
 
+:::{grid-item}
 ![image41.png](images/01-blocks-scripts-and-sprites/image41.png)
+:::
 
+:::{grid-item}
 ![image42.png](images/01-blocks-scripts-and-sprites/image42.png)
+:::
 
+:::{grid-item}
 ![image43.png](images/01-blocks-scripts-and-sprites/image43.png)
+:::
 
+:::{grid-item}
 ![image44.png](images/01-blocks-scripts-and-sprites/image44.png)
 :::
+
+::::
 
 
 In the block ![image40.png](images/01-blocks-scripts-and-sprites/image40.png){.image-inline}, the word “bark” is just an arbitrary name I made up. When you
@@ -801,9 +864,15 @@ Create a primitive using JavaScript\index{JavaScript}. (This block is
 disabled by default; the user must check “Javascript extensions” in the
 setting menu *each time* a project is loaded.)\index{pen down? block}
 
-::: {.evenly-spaced-images layout-ncol=2}
-![image150.png](images/01-blocks-scripts-and-sprites/image150.png){.image-inline}
+::::{grid} 2
+:class: evenly-spaced-images
+:gutter: 2
 
+:::{grid-item}
+![image150.png](images/01-blocks-scripts-and-sprites/image150.png){.image-inline}
+:::
+
+:::{grid-item}
 The {index}`\`at\` block<`at` block>` lets you examine the screen pixel
 \index{screen pixel} directly behind the rotation center of a sprite,
 the mouse, or an arbitrary (x,y) coordinate pair dropped onto the second
@@ -815,6 +884,8 @@ center (behind or in front). This is a hyperblock with respect to its
 second input.
 :::
 
+::::
+
 <!-- This needs 2 columns ??? -->
 ![image154.png](images/01-blocks-scripts-and-sprites/image154.png){.image-4x}
 
@@ -824,9 +895,14 @@ Checks the\index{is-a-block@`is \_ a \_ ?` block} data\index{stage blocks} type\
 ![image151.png](images/01-blocks-scripts-and-sprites/image151.png){.image-4x}
 ![image152.png](images/01-blocks-scripts-and-sprites/image152.png){.image-4x}
 
-::: {layout-ncol=2}
-![image155.png](images/01-blocks-scripts-and-sprites/image155.png){.image-4x}\index{set flag block}
+::::{grid} 2
+:gutter: 2
 
+:::{grid-item}
+![image155.png](images/01-blocks-scripts-and-sprites/image155.png){.image-4x}\index{set flag block}
+:::
+
+:::{grid-item}
 {index}`Turn the` text into a list,
 using the second input as the delimiter between items. The default
 delimiter, indicated by the brown dot in the input slot, is a single
@@ -841,6 +917,8 @@ into lists of lists; see @sec-csv. “Blocks”
 takes a script as the first input, reporting a list structure
 representing the structure of the script. See Chapter XI.
 :::
+
+::::
 
 ![image170.png](images/01-blocks-scripts-and-sprites/image170.png){.image-inline} For lists,
 \index{identical to} reports true only if its two input values are the
@@ -950,9 +1028,15 @@ visible sprites.
 \index{video block} has a {index}`snap option` that takes a
 snapshot and reports it as a costume. It is hyperized with respect to its second input.
 
-:::{.evenly-spaced-images layout-ncol=2}
-![image306.png](images/01-blocks-scripts-and-sprites/image306.png){.image-inline}
+::::{grid} 2
+:class: evenly-spaced-images
+:gutter: 2
 
+:::{grid-item}
+![image306.png](images/01-blocks-scripts-and-sprites/image306.png){.image-inline}
+:::
+
+:::{grid-item}
 ![image304.png](images/01-blocks-scripts-and-sprites/image304.png){.image-inline} The “neg” option\index{neg option} is a monadic\index{of block
 (operators)}\index{length of text block} negation operator
 \index{negation operator}, equivalent to “lg” is log<sub>2</sub>.
@@ -960,6 +1044,8 @@ snapshot and reports it as a costume. It is hyperized with respect to its second
 for positive input, 0 for zero input, or -1 for negative input.
 \index{set background block}
 :::
+
+::::
 
 <!-- ::: {.callout-tip} -->
 <!-- ## Two Different Length Of Blocks -->
@@ -973,9 +1059,15 @@ The ![length of text block](./blocks/images/block_reportTextAttribute.png){.imag
 you drop a list on the arrowheads, the block name
 changes to `sum` or `product`.
 
-::: {.evenly-spaced-images layout-ncol=2}
-![image309.png](images/01-blocks-scripts-and-sprites/image309.png)
+::::{grid} 2
+:class: evenly-spaced-images
+:gutter: 2
 
+:::{grid-item}
+![image309.png](images/01-blocks-scripts-and-sprites/image309.png)
+:::
+
+:::{grid-item}
 Extended\index{when I am block} mouse interaction events, sensing
 clicking, dragging, hovering, etc. The “stopped” option triggers when
 all scripts are stopped, as with the stop button; it is useful for
@@ -983,15 +1075,31 @@ robots whose hardware interface must be told to turn off motors. A `when I am st
 limited time.
 :::
 
-::: {.evenly-spaced-images layout-ncol=2}
-![image310.png](images/01-blocks-scripts-and-sprites/image310.png)
+::::
 
+::::{grid} 2
+:class: evenly-spaced-images
+:gutter: 2
+
+:::{grid-item}
+![image310.png](images/01-blocks-scripts-and-sprites/image310.png)
+:::
+
+:::{grid-item}
 {index}`Extended broadcast`: Click the right arrowhead to direct the message to a single sprite or the stage. Click again to add any value as a payload to the message. {#para-broadcast}
 :::
 
-::: {.evenly-spaced-images layout-ncol=2}
-![image311.png](images/01-blocks-scripts-and-sprites/image311.png){.image-4x}
+::::
 
+::::{grid} 2
+:class: evenly-spaced-images
+:gutter: 2
+
+:::{grid-item}
+![image311.png](images/01-blocks-scripts-and-sprites/image311.png){.image-4x}
+:::
+
+:::{grid-item}
 Extended `when I receive`\index{when I receive block}: Click the right
 arrowhead to expose a script variable (click on it to change its name,
 like any script variable) that will be set to the data of a matching
@@ -999,6 +1107,8 @@ broadcast. If the first input is set to “any message,” then the data
 variable will be set to the message, if no payload is included with the
 broadcast, or to a two-item list containing the message and the payload.
 :::
+
+::::
 
 ![image312.png](images/01-blocks-scripts-and-sprites/image312.png){.image-2x}
 
@@ -1033,9 +1143,15 @@ library.
 
 ![image362.png](images/01-blocks-scripts-and-sprites/image362.png)
 
-::: {.evenly-spaced-images layout-ncol=2}
-![image363.png](images/01-blocks-scripts-and-sprites/image363.png){.image-4x}
+::::{grid} 2
+:class: evenly-spaced-images
+:gutter: 2
 
+:::{grid-item}
+![image363.png](images/01-blocks-scripts-and-sprites/image363.png){.image-4x}
+:::
+
+:::{grid-item}
 The `of` block\index{of block (sensing)} has an extended menu of
 attributes of a sprite. Position reports an (x,y) vector. Size reports
 the percentage of normal size, as controlled by the set size block in
@@ -1044,6 +1160,8 @@ the corresponding edge of the sprite’s bounding box. Variables reports a
 list of the names of all variables in scope (global, sprite-local, and
 script variables if the right input is a script.)
 :::
+
+::::
 
 ## Libraries {#sec-libraries-intro}
 

--- a/02-saving-and-loading-projects-and/index.md
+++ b/02-saving-and-loading-projects-and/index.md
@@ -1,4 +1,9 @@
-# Saving and Loading Projects and Media {#sec-ch02}
+---
+toc: true
+---
+
+(sec-ch02)=
+# 2. Saving and Loading Projects and Media
 
 After you’ve created a project, you’ll want to save it, so that you can
 have access to it the next time you use {.snap}`Snap`. There are two ways to
@@ -14,7 +19,6 @@ like if you save locally. This is why we have multiple ways to save.
 In either case, if you choose "`Save as…`" from the File menu. You’ll see something like this:
 
 ![image487.png](assets/image487.png){#fig-saveas}
-<!--  style="width:3.54861in;height:2.57639in" / -->
 
 (If you are not logged in to your {.snap}`Snap` cloud account, Computer will
 be the only usable option.) The text box at the bottom right of the Save
@@ -34,11 +38,11 @@ choose "`Export project`" from the File menu.
 The other possibility is to
 save your project "`in the cloud`",\index{save your project in the cloud}
 at the {.snap}`Snap` web site. In order to do this, you need an account with
-us. Click on the {index}`Cloud button` (![image489.png](assets/image489.png) <!--  style="width:0.29167in;height:0.16667in" / --> ) in the Tool Bar.
+us. Click on the {index}`Cloud button` (![image489.png](assets/image489.png)) in the Tool Bar.
 Choose the “`Signup…`” option. This will show you a window that looks like
 the picture below:
 
-![image488.png](assets/image488.png) <!--  style="width:1.23403in;height:2.32986in" / -->
+![image488.png](assets/image488.png)
 
 You must choose a {index}`user name` that will identify you on
 the web site, such as `Jens`. If you’re a Scratch user, you can use
@@ -81,7 +85,7 @@ us say this.)
 Once you’ve created your account, you can log into it using the "`Login…`"
 option from the Cloud menu:
 
-![image490.png](assets/image490.png) <!--  style="width:1.6875in;height:2.02778in" / -->
+![image490.png](assets/image490.png)
 
 Use the user name and password that you set up earlier. If you check the
 "`Stay signed in`" box, then you will be logged in automatically the next
@@ -133,7 +137,7 @@ the Computer and Cloud options.
 
 If you are still in **{.snap}`Snap`** and realize that you’ve loaded another
 project without saving the one you were working on: ***Don’t edit the
-new project.*** From the File menu ![image384.png](assets/image384.png) <!--  style="width:0.31944in;height:0.18056in" alt="Macintosh HD:Users:bh:Desktop:Dropbox:manual (1):filebutton.png" / --> choose the "`Restore unsaved project`"
+new project.*** From the File menu ![image384.png](assets/image384.png) choose the "`Restore unsaved project`"
 option\index{Restore unsaved project option}.
 
 Restore unsaved project will also work if you log out of {.snap}`Snap` and

--- a/06-procedures-as-data/index.md
+++ b/06-procedures-as-data/index.md
@@ -338,12 +338,20 @@ block to choose between two expressions. {.snap}`Snap` has one, but we could
 write our own:
 
 <!-- TODO: The 2 + 1 layout is kind of a special case. -->
-:::{.evenly-spaced-images layout-ncol=2}
+::::{grid} 2
+:class: evenly-spaced-images
+:gutter: 2
+
+:::{grid-item}
 ![image736.png](assets/image736.png) <br/>
 ![image739.png](assets/image739.png)
+:::
 
+:::{grid-item}
 ![image737.png](assets/image737.png)
 :::
+
+::::
 
 Our block works for these simple examples, but if we try to use it in writing a
 {index}`recursive operator`, it’ll fail:
@@ -364,13 +372,23 @@ be of type [Reporter]{.mono} rather than type [Any]{.mono}. Then, when calling t
 those inputs will be enclosed in a `ring` so that the expressions
 themselves, rather than their values, become the inputs:
 
-:::{.evenly-spaced-images layout-ncol=3}
+::::{grid} 3
+:class: evenly-spaced-images
+:gutter: 2
+
+:::{grid-item}
 ![image740.png](assets/image740.png)
+:::
 
+:::{grid-item}
 ![image742.png](assets/image742.png)
+:::
 
+:::{grid-item}
 ![image741.png](assets/image741.png)
 :::
+
+::::
 
 In this version, the program works, with no infinite loop. But we’ve
 paid a heavy price: this `reporter-if` is no longer as intuitively obvious

--- a/appendix/a-snap-color-library/index.md
+++ b/appendix/a-snap-color-library/index.md
@@ -278,14 +278,22 @@ every-tenth-crayon selections don’t include it, so that all of the
 crayons in those smaller boxes are visible against a white\index{white}
 stage background.
 
-::: {.evenly-spaced-images layout-ncol="2"}
-![(attribution: Wikipedia user Andys. CC BY-SA.)](assets/image1198.png "(attribution: Wikipedia user Andys. CC BY-SA.)"){#fig-rainbow}
+::::{grid} 2
+:class: evenly-spaced-images
+:gutter: 2
 
+:::{grid-item}
+![(attribution: Wikipedia user Andys. CC BY-SA.)](assets/image1198.png "(attribution: Wikipedia user Andys. CC BY-SA.)"){#fig-rainbow}
+:::
+
+:::{grid-item}
 Among purples\index{purple}, the official spectral violet
 \index{violet} (crayon 90) is the end of the spectrum. Magenta
 \index{magenta}, brighter than violet, isn’t a spectral color at all.
 (In the picture at the left, the top part is the spectrum of white light spread out through a prism; the middle part is a photograph of a rainbow, and the bottom part is a digital simulation of a rainbow.) Magenta is a mixture of red and blue.
 :::
+
+::::
 
 The light gray at color number 10 is slightly different from crayon 10
 just because of roundoff in computing crayon values. Color number 90 is


### PR DESCRIPTION
## Convert Chapters 1 & 2 from Quarto to JupyterBook 2 format

Addresses the ongoing Quarto → JupyterBook 2 migration by fixing layout rendering in Chapter 1 and drafting the Chapter 2 conversion.

## Changes

- **Chapter 1** (`01-blocks-scripts-and-sprites.md`): Replace all Quarto-specific `::: {layout-ncol=N}` blocks with MyST `{grid}` directives, fixing multi-column layout rendering in JupyterBook. Same fix applied to `06-procedures-as-data/index.md` and `appendix/a-snap-color-library/index.md` for consistency.
- **Chapter 2** (`02-saving-and-loading-projects-and/index.md`): Add MyST frontmatter (`toc: true`), update chapter title and header anchor to MyST style (`(sec-ch02)=`), and remove legacy inline HTML style comments. A `TODO` is preserved for a missing image asset (`image391.png`).
- All referenced image assets verified as present.

## Reviewer Notes

- The `{grid}` directive replaces `layout-ncol` which is Quarto-only and not recognized by the MyST parser or the project's CSS.
- Chapter 2 changes are intentionally minimal — structural cleanup only, no content edits.
- The missing `image391.png` in Chapter 2 is a pre-existing issue flagged with a TODO and not introduced by this PR.

---

[Superconductor Ticket Implementation](https://www.superconductor.com/tickets/9TqrmM7tqKnb/implementations/P8hLNgK9tkmf) | [Guided Review](https://www.superconductor.com/tickets/9TqrmM7tqKnb/implementations/P8hLNgK9tkmf?tab=guided_review)

<!-- created-by-superconductor -->