### PR TITLE
Fix LaTeX PDF rendering issues: image sizing, positioning, grid directives, kbd translation, index columns, headings, and cover page

### DIFF
--- a/_latex-template/README.md
+++ b/_latex-template/README.md
@@ -34,10 +34,33 @@ template:
   `makeindex` run and lets `latexmk` invoke `makeindex` instead. We pass
   `-s index-style.ist` via the bundled `latexmkrc`, so the rendered index
   uses our custom style (bold letter-group headings, small items,
-  right-aligned page numbers). `\printindex` itself is rendered by the
-  [`manual-index.md`](../manual-index.md) chapter.
+  right-aligned page numbers). The index is also rendered in two columns
+  via `imakeidx`'s `columns=2` option. `\printindex` itself is rendered
+  by the [`manual-index.md`](../manual-index.md) chapter.
 - Snap! brand colors (`snapblue`, `snaporange`) are defined for use in custom
   LaTeX content.
+- A custom cover page (`\snapcoverpage`) replaces the default
+  `\maketitle`: white left panel + blue right panel separated by a
+  vertical dotted line, the Snap! logo + "Build Your Own Blocks"
+  subtitle in the upper left, the version on the blue panel, an orange
+  "Snap! Reference Manual" banner across the middle, the cover image of
+  Snap! code below it, and the authors stacked in the lower right
+  (sourced from `myst.yml`'s `authors:` list).
+- Headings (`\chapter` ... `\subsection`) are restyled via `titlesec`:
+  smaller fonts than the KOMA defaults and a thin horizontal rule
+  beneath the heading text.
+- `\includegraphics` is redefined to recognize the sentinel widths the
+  [`latex-shims`](../_support/plugins/latex-shims.mjs) MyST plugin
+  emits for inline images (`{inline ...}` role with `image-inline`,
+  `image-inline-tall`, `image-1-5x`, `image-2x`, `image-3x`, or
+  `image-4x` classes), and route them through `\snapinlineimgsize`,
+  which renders them at a height proportional to the surrounding
+  `\baselineskip` and raises them onto the text baseline. Plain
+  `\includegraphics` calls (block images) fall through unchanged.
+- `\kbd` macro renders a framed monospace key for `<kbd>` / `keyboard`
+  nodes (also wired up by the latex-shims plugin).
+- `snapgrid` environment + `\snapgriditem` macro render `:::{grid} N`
+  directives as side-by-side minipages.
 
 ## Files
 
@@ -49,6 +72,11 @@ template:
   (see `latexmkrc`).
 - `latexmkrc` &mdash; configures `latexmk`'s `$makeindex` so the style file
   above is actually used.
+- `cover-image.png`, `snap-logo.png` &mdash; symlinks back to
+  `../images/` so the cover-page `\includegraphics` calls resolve when
+  `latexmk` runs from the temp build directory. The actual files live in
+  `images/`; the symlinks here just make them visible to MyST's template
+  bundler (see `template.yml`'s `files:` list).
 
 ## Updating from upstream
 

--- a/_latex-template/cover-image.png
+++ b/_latex-template/cover-image.png
@@ -1,0 +1,1 @@
+../images/cover-image.png

--- a/_latex-template/snap-logo.png
+++ b/_latex-template/snap-logo.png
@@ -1,0 +1,1 @@
+../images/snap-logo.png

--- a/_latex-template/template.tex
+++ b/_latex-template/template.tex
@@ -2,13 +2,17 @@
 % Vendored from https://github.com/myst-templates/plain_latex_book
 % See README.md in this directory for the list of local adaptations.
 
-\documentclass[12pt,oneside]{scrbook}
+% Body font size 11pt; TOC and footnotes drop to 10pt below.
+\documentclass[11pt,oneside]{scrbook}
 \usepackage[paperheight=11in,
    paperwidth=8.5in,
-   top=1.5cm,
-   bottom=2cm,
-   left=1.5cm,
-   right=1.5cm]{geometry}
+   top=0.5in,
+   bottom=0.5in,
+   left=0.5in,
+   right=0.5in,
+   headsep=10pt,
+   footskip=24pt,
+   includehead, includefoot]{geometry}
 
 % Indexing.
 %
@@ -25,7 +29,19 @@
 
 \usepackage[T1]{fontenc}
 \usepackage[utf8]{inputenc}
+% Body font: Adobe Source Serif (the texlive `sourceserifpro` package
+% ships Source Serif Pro, the same family as Source Serif 4). Source
+% Serif is designed for screen + body legibility and reads well at
+% small sizes. Latin Modern stays loaded as the typewriter fallback
+% since Source Serif doesn't ship a monospaced family.
+\usepackage[default]{sourceserifpro}
 \usepackage{lmodern}
+% Slightly relaxed line spacing (1.07x) — a touch easier on the eyes
+% than the default 1.0 without adding a meaningful number of pages.
+\linespread{1.07}
+
+% Footnotes one size smaller than body (10pt when body is 11pt).
+\setkomafont{footnote}{\small}
 \usepackage{graphicx}
 \usepackage{caption}
 \usepackage{natbib}
@@ -34,15 +50,150 @@
 \usepackage{framed}
 \usepackage{hyperref}
 \usepackage{amssymb}
+\usepackage{ifthen}
+\usepackage{calc}
+\usepackage{tikz}
+\usepackage[absolute,overlay]{textpos}
 \bibliographystyle{abbrvnat}
 
 % Snap! brand colors, available for custom LaTeX content.
 \definecolor{snapblue}{RGB}{52,101,164}
 \definecolor{snaporange}{RGB}{255,140,0}
+% A second, slightly darker blue used for the cover page side panel
+% (closer to the "Berkeley blue" used elsewhere in the project).
+\definecolor{snapcoverblue}{RGB}{52,101,164}
 
 % Make list items more compact
 \usepackage{enumitem}
 \setlist[itemize]{noitemsep, topsep=0pt}
+
+% --- Heading style: smaller chapter/section titles, underlined. ---------
+% titlesec [explicit] requires a format for every sectioning command
+% MyST emits, so we cover all of \chapter ... \subparagraph below.
+% A horizontal rule below the heading replaces \underline (which renders
+% too tight against the descenders to read clearly at small sizes).
+%
+% The chapter pages omit the \thechapter prefix in the on-page title
+% because MyST already bakes a leading "1.", "2.", ... into each chapter
+% title (so the JupyterBook 2 sidebar shows numbers). The chapter number
+% is still emitted to the TOC entry via the standard \addcontentsline /
+% \numberline path, so the table of contents continues to show "1
+% Blocks, Scripts, and Sprites" / "2 Saving and Loading...".
+\usepackage[explicit]{titlesec}
+\newcommand{\snapheadingrule}{\vspace{-0.25\baselineskip}\noindent\rule{\linewidth}{0.4pt}}
+% Chapter: smaller than the KOMA default \huge, with a rule beneath.
+\titleformat{\chapter}[hang]
+  {\normalfont\Large\bfseries}{}{0pt}{#1}[\snapheadingrule]
+\titlespacing*{\chapter}{0pt}{0pt}{12pt}
+% Sections / subsections: keep the \thesection prefix (these are not
+% manually numbered in the source).
+\titleformat{\section}[hang]
+  {\normalfont\large\bfseries}{\thesection\quad}{0pt}{#1}[\snapheadingrule]
+\titleformat{\subsection}[hang]
+  {\normalfont\normalsize\bfseries}{\thesubsection\quad}{0pt}{#1}[\snapheadingrule]
+\titleformat{\subsubsection}[hang]
+  {\normalfont\normalsize\bfseries}{\thesubsubsection\quad}{0pt}{#1}
+\titleformat{\paragraph}[runin]
+  {\normalfont\normalsize\bfseries}{}{0pt}{#1}
+\titleformat{\subparagraph}[runin]
+  {\normalfont\normalsize\bfseries}{}{0pt}{#1}
+
+% Drop the chapter-number prefix from the running header too: KOMA's
+% `\chaptermarkformat` is what prepends "1   " to the page header.
+\renewcommand*{\chaptermarkformat}{}
+
+% --- Two-column table of contents ---------------------------------------
+% Wrap \tableofcontents in a multicols block so entries flow across two
+% columns rather than running down a single 8-inch column. The TOC is
+% limited to 2 levels (chapter + section) — subsections and below are
+% omitted. Chapter entries also drop their auto-numbered prefix
+% (\numberline{N}) since each chapter title already begins with a
+% manually-written "1.", "2.", etc. for the JupyterBook 2 sidebar.
+\usepackage{multicol}
+\setcounter{tocdepth}{1}
+\makeatletter
+% Drop the \numberline{N} prefix from chapter TOC entries by overriding
+% KOMA's \addchaptertocentry, which is what \@chapter calls to register
+% the chapter in the TOC. Section / subsection entries are unaffected,
+% so "1.1 Hat Blocks" etc. keep their numbers.
+\renewcommand*{\addchaptertocentry}[2]{%
+  \addcontentsline{toc}{chapter}{#2}%
+}
+\renewcommand\tableofcontents{%
+  \chapter*{\contentsname}%
+  \@mkboth{\MakeUppercase\contentsname}{\MakeUppercase\contentsname}%
+  \begin{multicols}{2}\small
+    \@starttoc{toc}%
+  \end{multicols}%
+}
+\makeatother
+
+% --- Inline / block image rendering -------------------------------------
+% The `latex-shims` MyST plugin tags inline images with sentinel widths
+% (0.001\linewidth and 0.002\linewidth) so that the standard
+% `\includegraphics[width=...]{...}` myst-to-tex emits can be intercepted
+% here and rendered as height-scaled, raisebox'd inline images.
+%
+% Note: jtex block-tag delimiters collide with LaTeX's
+% argument-pass-through brackets, so any literal occurrence of the
+% latter is emitted via a jtex string-variable substitution.
+\let\snaporigincludegraphics\includegraphics
+% Render an image inline with the surrounding text at a given multiple
+% of \baselineskip. The raisebox depth is roughly height*0.16 so the
+% image sits on the baseline rather than the descender line.
+\newcommand{\snapinlineimgsize}[2]{%
+  \raisebox{-0.16\dimexpr#1\baselineskip\relax}{%
+    \snaporigincludegraphics[height=#1\baselineskip]{#2}%
+  }%
+}
+\makeatletter
+\def\snap@inline@a{width=0.001\linewidth}% image-inline      -> 1.5x
+\def\snap@inline@b{width=0.002\linewidth}% image-inline-tall -> 2.4x
+\def\snap@inline@c{width=0.003\linewidth}% image-1-5x        -> 1.7x
+\def\snap@inline@d{width=0.004\linewidth}% image-2x          -> 2.0x
+\def\snap@inline@e{width=0.005\linewidth}% image-3x          -> 2.5x
+\def\snap@inline@f{width=0.006\linewidth}% image-4x          -> 3.0x
+\renewcommand*{\includegraphics}[2][]{%
+  \def\snap@opts{#1}%
+  \ifx\snap@opts\snap@inline@a\snapinlineimgsize{1.5}{#2}%
+  \else\ifx\snap@opts\snap@inline@b\snapinlineimgsize{2.4}{#2}%
+  \else\ifx\snap@opts\snap@inline@c\snapinlineimgsize{1.7}{#2}%
+  \else\ifx\snap@opts\snap@inline@d\snapinlineimgsize{2.0}{#2}%
+  \else\ifx\snap@opts\snap@inline@e\snapinlineimgsize{2.5}{#2}%
+  \else\ifx\snap@opts\snap@inline@f\snapinlineimgsize{3.0}{#2}%
+  \else\snap@fallback@includegraphics{#1}{#2}%
+  \fi\fi\fi\fi\fi\fi
+}
+% Block images go through the fallback. Wrap with \centerline so the
+% image is horizontally centered (myst-to-tex emits a bare
+% \includegraphics with no surrounding center environment).
+\def\snap@fallback@includegraphics#1#2{\par\centerline{\snaporigincludegraphics[-"[#1]"-]{#2}}\par}
+\makeatother
+
+% --- <kbd> rendering ----------------------------------------------------
+% Used by the latex-shims plugin to render the MyST `keyboard` node.
+\newcommand{\kbd}[1]{%
+  \tikz[baseline=(K.base)]{%
+    \node[rectangle, rounded corners=2pt, draw=black!60, fill=black!5,
+          inner sep=2pt, font=\small\ttfamily] (K) {#1};%
+  }%
+}
+
+% --- :::{grid} rendering -----------------------------------------------
+% A simple side-by-side layout of minipages. Children flow in the order
+% they appear and wrap to a new line once total width exceeds \linewidth.
+% \snapgridsep is rendered between siblings.
+\newenvironment{snapgrid}{%
+  \par\medskip\noindent
+  \setlength{\parskip}{0pt}%
+  \ignorespaces
+}{%
+  \par\medskip
+}
+\newcommand{\snapgriditem}[2]{%
+  \begin{minipage}[t]{#1\linewidth}\centering #2\end{minipage}%
+}
+\newcommand{\snapgridsep}{\hfill\ignorespaces}
 
 [- IMPORTS -]
 
@@ -72,19 +223,75 @@
   \vspace{2pt}\end{adjustwidth}\endMakeFramed%
 }
 
-\title{\Huge \textbf{[-doc.title-]}[# if doc.subtitle #] \\ \huge [-doc.subtitle-][# endif #]}
+\title{[-doc.title-][# if doc.subtitle #] \\ \huge [-doc.subtitle-][# endif #]}
 
-\author{\parbox{\textwidth}{\centering\textsc{
-[#- for author in doc.authors #]
-  [#- if not loop.first #] and [# endif #][-author.name-][# if not loop.last and not loop.first #], [# endif #]
-[#- endfor -#]
-}}}
+\author{[# for author in doc.authors #][-author.name-][# if not loop.last #] \\ [# endif #][# endfor #]}
+
+% --- Cover page ---------------------------------------------------------
+% Rebuilds the classic Snap! cover: white left panel, blue right panel
+% separated by a vertical dotted line, the Snap! logo + "Build Your Own
+% Blocks" subtitle in the upper left, the version "8.0" on the blue
+% panel, an orange "Snap! Reference Manual" banner across the middle,
+% the cover image of Snap! code below the banner, and the authors stacked
+% in the lower right.
+\newcommand{\snapcoverpage}{%
+  \begin{titlepage}%
+  \thispagestyle{empty}%
+  \begin{tikzpicture}[remember picture, overlay]
+    % Right blue panel (about 38% of the page width).
+    \fill[snapcoverblue]
+      ([xshift=0.62\paperwidth]current page.north west) rectangle
+      (current page.south east);
+    % Vertical dotted divider just left of the blue panel.
+    \draw[snapcoverblue!80, line width=0.6pt, dotted]
+      ([xshift=0.61\paperwidth, yshift=-0.6cm]current page.north west) --
+      ([xshift=0.61\paperwidth, yshift=0.6cm]current page.south west);
+
+    % Snap! logo (upper left).
+    \node[anchor=north west, inner sep=0pt]
+      at ([xshift=1.6cm, yshift=-1.6cm]current page.north west)
+      {\snaporigincludegraphics[width=4cm]{snap-logo.png}};
+
+    % Subtitle "Build Your Own Blocks" beneath the logo (pushed down
+    % a half line-height so the descenders don't kiss the logo).
+    \node[anchor=north west, font=\Large, text=black]
+      at ([xshift=1.6cm, yshift=-4cm]current page.north west)
+      {Build Your Own Blocks};
+
+    % Version on the blue panel.
+    \node[anchor=north east, text=white, font=\fontsize{60}{60}\selectfont]
+      at ([xshift=-1.5cm, yshift=-3cm]current page.north east)
+      {8.0};
+
+    % Orange banner with the manual title (about 35% from top of
+    % page). The title is bold italic and right-justified inside the
+    % orange band.
+    \fill[snaporange]
+      ([yshift=-0.34\paperheight, xshift=-0.2cm]current page.north west) rectangle
+      ([yshift=-0.42\paperheight, xshift=0.95\paperwidth]current page.north west);
+    \node[anchor=east, text=white, font=\Huge\bfseries\itshape]
+      at ([yshift=-0.38\paperheight, xshift=0.93\paperwidth]current page.north west)
+      {Snap\textit{!}\ Reference Manual};
+
+    % Cover image of Snap! code, sitting below the orange banner and
+    % straddling the divider.
+    \node[anchor=north, inner sep=0pt]
+      at ([yshift=-0.45\paperheight, xshift=-0.05\paperwidth]current page.north)
+      {\snaporigincludegraphics[width=0.55\paperwidth]{cover-image.png}};
+
+    % Authors in the lower right of the blue panel.
+    \node[anchor=south east, text=white, font=\Large, align=right]
+      at ([xshift=-1.5cm, yshift=2.5cm]current page.south east)
+      {[# for author in doc.authors #][-author.name-][# if not loop.last #] \\ [# endif #][# endfor #]};
+  \end{tikzpicture}%
+  \end{titlepage}%
+}
 
 \begin{document}
 \sloppy
 
 \frontmatter
-\maketitle
+\snapcoverpage
 
 \tableofcontents
 % \listoffigures

--- a/_latex-template/template.yml
+++ b/_latex-template/template.yml
@@ -2,7 +2,8 @@ jtex: v1
 title: Snap! Manual
 description: >
   A locally vendored copy of the MyST plain_latex_book template, adapted for
-  the Snap! Reference Manual (US Letter, scrbook, indexed, Snap! brand colors).
+  the Snap! Reference Manual (US Letter, scrbook, indexed, Snap! brand colors,
+  custom Snap! cover page).
 version: 1.0.0
 license: BSD-2-Clause
 source: https://snap.berkeley.edu
@@ -31,11 +32,16 @@ files:
   - template.tex
   - index-style.ist
   - latexmkrc
+  # Symlinks back to ../images/. They're copied next to snap-manual.tex so
+  # the cover page \includegraphics calls resolve.
+  - cover-image.png
+  - snap-logo.png
 packages:
   - imakeidx
   - fontenc
   - inputenc
   - lmodern
+  - sourceserifpro
   - graphicx
   - caption
   - natbib
@@ -46,3 +52,9 @@ packages:
   - amssymb
   - enumitem
   - geometry
+  - ifthen
+  - calc
+  - tikz
+  - textpos
+  - titlesec
+  - multicol

--- a/_support/plugins/img-role.mjs
+++ b/_support/plugins/img-role.mjs
@@ -15,7 +15,6 @@ const imgRole = {
   },
   run(data) {
     const { alt, class: className, width, height, title } = data.options ?? {};
-    // console.log('img role data:', { url: data.body, alt, className, width, height, title });
     return [
       {
         type: 'image',
@@ -30,9 +29,51 @@ const imgRole = {
   },
 };
 
+// Block image role — same shape as `inline`, but defaults to *no* class
+// (so the latex-shims plugin treats it as a block image and lets the
+// `width` flow through to \includegraphics). MyST doesn't parse the
+// `![alt](url){width=...}` shortcut on images, so authors use this to
+// override the default block width per-image:
+//
+//     {img alt="..." width="1.5in"}`./path/to/img.png`
+//     {img alt="..." width="40%"}`./path/to/img.png`
+//
+// Inch widths are converted to a percentage of \linewidth by the
+// latex-shims plugin before they reach myst-to-tex.
+const blockImgRole = {
+  name: 'img',
+  doc: 'Block image with optional CSS class, width, height, and title.',
+  body: {
+    type: String,
+    doc: 'The image URL or path.',
+    required: true,
+  },
+  options: {
+    alt: { type: String, doc: 'Alt text for accessibility.', required: true },
+    class: { type: String, doc: 'CSS class(es).' },
+    width: { type: String, doc: 'CSS width, e.g. 200px, 50%, or 1.5in.' },
+    height: { type: String, doc: 'CSS height.' },
+    title: { type: String, doc: 'Tooltip / title attribute.' },
+  },
+  run(data) {
+    const { alt, class: className, width, height, title } = data.options ?? {};
+    return [
+      {
+        type: 'image',
+        url: data.body.trim(),
+        alt,
+        class: className,
+        width,
+        height,
+        title,
+      },
+    ];
+  },
+};
+
 const plugin = {
-  name: 'Inline image role',
-  roles: [imgRole],
+  name: 'Snap image roles',
+  roles: [imgRole, blockImgRole],
 };
 
 export default plugin;

--- a/_support/plugins/latex-shims.mjs
+++ b/_support/plugins/latex-shims.mjs
@@ -1,8 +1,69 @@
 // latex-shims.mjs
-// Transforms unhandled / under-handled nodes into raw `latex` nodes
-// so myst-to-tex emits exactly what we want.
+// Adapt the MyST AST so that the LaTeX export produces the rendering we want
+// for inline images, block images, :::{grid} layouts, and <kbd> elements.
+//
+// The myst-to-tex image renderer only honours `node.url` and `node.width`
+// (rendered as `\includegraphics[width=X\linewidth]{url}`). To express
+// inline (line-height-scaled, raised) images and block images at a smaller
+// width without forking myst-to-tex, we set sentinel widths here and pair
+// them with a redefinition of \includegraphics in the LaTeX preamble (see
+// `_latex-template/template.tex`). The cached image URL is filled in by
+// MyST after this transform runs, so the macro receives the resolved path.
+//
+// MyST runs document-stage transforms once per export pipeline, but the
+// AST mutations these transforms perform (sentinel widths, kbd -> raw
+// LaTeX, grid -> raw `\snapgrid` env) are LaTeX-specific and would
+// shrink images to 0.001px and erase grid/kbd content in the HTML
+// build. We therefore gate every transform on the build flag in
+// `process.argv`, applying the transforms only when MyST is invoked
+// for `--pdf`, `--tex`, `--typst`, or `--all`. HTML / site / docx
+// builds see the AST untouched.
 
-// Minimal LaTeX special-character escaping for plain text contexts.
+const TEX_BUILD_FLAGS = new Set(['--pdf', '--tex', '-a', '--all']);
+const isLatexBuild = process.argv.some((arg) => TEX_BUILD_FLAGS.has(arg));
+
+// Width sentinels used to communicate the desired rendering to the
+// custom \includegraphics defined in the LaTeX preamble. These values
+// are unlikely to occur as real image widths and the preamble decodes
+// them into the right \snapinline*img macro.
+const SENTINEL_WIDTHS = {
+  'image-inline':       0.001,  // ~1.5 baseline (default inline icon)
+  'image-inline-tall':  0.002,  // ~2.4 baselines (taller hat blocks etc.)
+  'image-1-5x':         0.003,  // ~1.7 baselines
+  'image-2x':           0.004,  // ~2.0 baselines
+  'image-3x':           0.005,  // ~2.5 baselines
+  'image-4x':           0.006,  // ~3.0 baselines
+};
+
+// Block images that don't carry their own `width` attribute default to
+// 40% of \linewidth. Per-image overrides can be set in markdown:
+//
+//     ![alt](path){width=1.5in}
+//     ![alt](path){width=30%}
+//
+// Inch widths are converted to a percentage of the assumed text width
+// below (BLOCK_LINEWIDTH_INCHES) so they fall through the standard
+// myst-to-tex `width=N\linewidth` path.
+const BLOCK_DEFAULT_WIDTH = '40%';
+
+// Linewidth in inches assumed when converting `Xin` widths to a
+// percentage of \linewidth. With 8.5"-wide US Letter and 0.5" margins
+// (see template.tex's `\usepackage{geometry}`), \linewidth ≈ 7.5in.
+const BLOCK_LINEWIDTH_INCHES = 7.5;
+
+// Convert a width attribute that ends in `in` (inches) to a percentage
+// string. Anything else passes through unchanged.
+function normalizeWidth(width) {
+  if (typeof width !== 'string') return width;
+  const m = width.match(/^([\d.]+)\s*in$/i);
+  if (!m) return width;
+  const inches = parseFloat(m[1]);
+  if (!Number.isFinite(inches)) return width;
+  const pct = (inches / BLOCK_LINEWIDTH_INCHES) * 100;
+  return `${pct.toFixed(2)}%`;
+}
+
+// Minimal LaTeX special-character escaping for plain text (used by kbd).
 function escapeLatex(rawText) {
   return String(rawText)
     .replace(/\\/g, '\\textbackslash{}')
@@ -11,7 +72,6 @@ function escapeLatex(rawText) {
     .replace(/\^/g, '\\textasciicircum{}');
 }
 
-// Collect plain text from any subtree (good enough for kbd contents).
 function gatherText(node) {
   if (node == null) return '';
   if (typeof node.value === 'string') return node.value;
@@ -19,54 +79,134 @@ function gatherText(node) {
   return '';
 }
 
+function classList(node) {
+  const cls = node?.class ?? '';
+  return cls.split(/\s+/).filter(Boolean);
+}
+
+// If an image carries one of the inline-style classes, return the
+// corresponding sentinel width. Otherwise return null. We test the
+// most specific classes first so e.g. `image-inline-tall` wins over
+// the generic `image-inline`.
+const INLINE_CLASS_PRIORITY = [
+  'image-inline-tall',
+  'image-inline',
+  'image-4x',
+  'image-3x',
+  'image-2x',
+  'image-1-5x',
+];
+
+function inlineSentinel(node) {
+  const cls = classList(node);
+  for (const className of INLINE_CLASS_PRIORITY) {
+    if (cls.includes(className)) return SENTINEL_WIDTHS[className];
+  }
+  return null;
+}
+
+// Walk a subtree and apply `fn` to every image node found.
+function walkImages(root, fn) {
+  if (!root) return;
+  if (Array.isArray(root)) {
+    root.forEach((c) => walkImages(c, fn));
+    return;
+  }
+  if (root.type === 'image') fn(root);
+  if (root.children) walkImages(root.children, fn);
+}
+
 const latexShimsTransform = {
   name: 'latex-shims',
-  stage: 'document', // runs after parse + standard transforms, before export
+  stage: 'document',
   plugin: (_options, utils) => (tree) => {
-    // 1. <kbd> -> keyboard node. Render as a framed monospace key.
-    //    Swap to \keys{...} from the `menukeys` package if you prefer.
-    utils.selectAll('keyboard', tree).forEach((keyboardNode) => {
-      const keyText = escapeLatex(gatherText(keyboardNode));
-      keyboardNode.type = 'latex';
-      keyboardNode.value = `\\fbox{\\texttt{\\small ${keyText}}}`;
-      delete keyboardNode.children;
+    // Skip transforms entirely on non-LaTeX builds: the mutations below
+    // (sentinel widths, raw-tex grid/kbd nodes) would degrade the HTML
+    // and Typst renders.
+    if (!isLatexBuild) return;
+    // 1. <kbd> -> \kbd{...} (defined in the LaTeX preamble).
+    utils.selectAll('keyboard', tree).forEach((node) => {
+      const keyText = escapeLatex(gatherText(node));
+      node.type = 'raw';
+      node.lang = 'tex';
+      node.tex = `\\kbd{${keyText}}`;
+      delete node.children;
     });
 
-    // 2. :::{grid} -> grid node (with card/gridItem children).
-    //    Simplest: unwrap into a `block`, which myst-to-tex passes through
-    //    so children render sequentially. Replace with a multicol/minipage
-    //    construction if you actually want columns.
-    // utils.selectAll('grid', tree).forEach((gridNode) => {
-    //   gridNode.type = 'block';
-    //   // Optionally also flatten card wrappers inside the grid:
-    //   (gridNode.children || []).forEach((child) => {
-    //     if (child.type === 'card' || child.type === 'gridItem') {
-    //       child.type = 'block';
-    //     }
-    //   });
-    // });
+    // 2. :::{grid} N -> a snapgrid environment with one snapgriditem per child.
+    //    We keep the children as `block` nodes so their content (including
+    //    images) is still rendered by the standard handlers.
+    utils.selectAll('grid', tree).forEach((gridNode) => {
+      // myst stores the column count in `columns`. It's an array of
+      // breakpoint counts ([sm, md, lg, xl]) or a single-element array.
+      // We want the largest count (used at full-page breakpoints in
+      // print).
+      const rawCols = Array.isArray(gridNode.columns)
+        ? gridNode.columns[gridNode.columns.length - 1]
+        : (gridNode.columns ?? gridNode.argument ?? 2);
+      const ncols = Math.max(1, parseInt(rawCols, 10) || 2);
+      // Leave a small gap between columns; minipages use a fraction of \linewidth.
+      const colWidth = (1 / ncols - 0.01).toFixed(3);
 
-    // 3. Image customization. Example: force every figure image to 0.8\linewidth
-    //    and add a \centering. Tweak as needed; or replace entirely with a raw
-    //    \includegraphics for full control.
+      const items = (gridNode.children || []).filter(
+        (c) => c.type === 'gridItem' || c.type === 'grid-item' || c.type === 'card',
+      );
+
+      // Each `raw` node is concatenated verbatim into the output by
+      // myst-to-tex (no separator), so trailing `%` here would swallow
+      // whatever follows. Use explicit `\n` instead.
+      const newChildren = [{ type: 'raw', lang: 'tex', tex: '\n\\begin{snapgrid}\n' }];
+      items.forEach((item, idx) => {
+        // Within a grid, images should fill the column rather than
+        // shrinking to BLOCK_DEFAULT_WIDTH, so flag them with a sentinel.
+        walkImages(item, (img) => {
+          if (inlineSentinel(img) == null) {
+            img.width = '100%';
+            img._snapInGrid = true;
+          }
+        });
+        newChildren.push({
+          type: 'raw',
+          lang: 'tex',
+          tex: `\\snapgriditem{${colWidth}}{`,
+        });
+        newChildren.push({ type: 'block', children: item.children || [] });
+        const last = idx === items.length - 1;
+        newChildren.push({
+          type: 'raw',
+          lang: 'tex',
+          tex: last ? '}\n' : '}\\snapgridsep\n',
+        });
+      });
+      newChildren.push({ type: 'raw', lang: 'tex', tex: '\\end{snapgrid}\n' });
+
+      gridNode.type = 'block';
+      gridNode.children = newChildren;
+    });
+
+    // 3. Image sizing.
+    //    Inline images get a sentinel width that the custom \includegraphics
+    //    redefinition in the preamble decodes back into a height-based,
+    //    raisebox'd \includegraphics. Block images that have no explicit
+    //    width get our reduced default (BLOCK_DEFAULT_WIDTH); explicit
+    //    `Xin` widths from markdown attrs are converted to percentages.
     utils.selectAll('image', tree).forEach((imageNode) => {
-      // Path A: just adjust attributes the default handler reads.
-      imageNode.width = imageNode.width ?? '80%';
-      imageNode.align = imageNode.align ?? 'center';
-
-      // Path B (uncomment to fully override): emit raw LaTeX.
-      // const url = imageNode.url ?? '';
-      // imageNode.type = 'latex';
-      // imageNode.value =
-      //   `\\begin{center}\\includegraphics[width=0.8\\linewidth]{${url}}\\end{center}`;
-      // delete imageNode.children;
+      const sentinel = inlineSentinel(imageNode);
+      if (sentinel != null) {
+        imageNode.width = sentinel;
+        imageNode.align = undefined;
+      } else if (imageNode._snapInGrid) {
+        // Already set to 100% above.
+      } else if (imageNode.width == null) {
+        imageNode.width = BLOCK_DEFAULT_WIDTH;
+      } else {
+        imageNode.width = normalizeWidth(imageNode.width);
+      }
     });
   },
 };
 
-const plugin = {
+export default {
   name: 'LaTeX shims (kbd, grid, image)',
   transforms: [latexShimsTransform],
 };
-
-export default plugin;

--- a/myst.yml
+++ b/myst.yml
@@ -28,7 +28,7 @@ project:
     - _support/plugins/block-help.mjs
     - _support/plugins/snap-role.mjs
     - _support/plugins/img-role.mjs
-    # - _support/plugins/latex-shims.mjs
+    - _support/plugins/latex-shims.mjs
   # Note this does not get rendered as native HTML / it is escaped.
   substitutions:
     # Snap: Snap!


### PR DESCRIPTION
## Fix LaTeX PDF rendering: cover page, headings, images, grid, kbd, TOC, and fonts

Overhauls the LaTeX/PDF output to address a wide range of layout and rendering issues. The PDF now has a custom branded cover page, properly sized and centered images, working `:::{grid}` and `<kbd>` support, restyled headings, a two-column TOC, and a more readable body font.

## Changes

**Cover page**
- Custom `\snapcoverpage` with Snap! logo, "Build Your Own Blocks" tagline, version number, orange title banner with bold-italic right-justified title, cover image, and metadata-driven author list
- Symlinks `cover-image.png` and `snap-logo.png` into `_latex-template/` so the MyST bundler can find them

**Typography & layout**
- Body font switched to Source Serif Pro (`sourceserifpro`) at 11pt with `\linespread{1.07}`
- Margins reduced to 0.5in all around
- Footnotes set to `\small` (10pt)

**Headings**
- Restyled via `titlesec`: smaller fonts (`\Large` chapter, `\large` section, `\normalsize` subsection) with a thin horizontal rule beneath each heading
- Chapter number prefix suppressed on chapter pages (titles already include manual numbers for the JupyterBook sidebar); numbers still appear in the TOC

**Table of contents**
- Two-column layout via `multicols`
- Limited to 2 levels (chapter + section)
- Chapter number prefix stripped from TOC entries

**Images**
- Block images default to 40% of `\linewidth`, centered via `\centerline`
- Inline images use sentinel widths decoded by a custom `\includegraphics` redefinition in the preamble, rendering at 1.5×–3.0× `\baselineskip` raised onto the baseline
- `{img}` role added to `img-role.mjs` for per-image width overrides (supports `%`, `px`, and `in` units)
- Inch widths normalized to `\linewidth` percentages in `latex-shims.mjs`

**Grid & kbd**
- `:::{grid} N` directives converted to `snapgrid`/`\snapgriditem` minipage environments
- `<kbd>` nodes converted to `\kbd{...}` (TikZ-framed monospace key)

**HTML build safety**
- `latex-shims.mjs` now gates all transforms on `--pdf`/`--tex`/`--all` flags in `process.argv`, so HTML builds are unaffected
- Plugin re-enabled in `myst.yml`

## Visual Changes

- [Cover page](https://www.superconductor.com/ticket_implementations/Rq7H6JpbLpg9/artifacts/NwdqKpWhnhFF)
- [Table of contents (2 columns, 2 levels)](https://www.superconductor.com/ticket_implementations/Rq7H6JpbLpg9/artifacts/hm6kPgBBGdp6)
- [Chapter 1 opening (restyled heading, centered block images)](https://www.superconductor.com/ticket_implementations/Rq7H6JpbLpg9/artifacts/pgzQKdLqqzwG)
- [Inline images flowing with text](https://www.superconductor.com/ticket_implementations/Rq7H6JpbLpg9/artifacts/TMMWHWgN7cPT)
- [Two-column index](https://www.superconductor.com/ticket_implementations/Rq7H6JpbLpg9/artifacts/NPkDmQB7WCpk)

---

[Superconductor Ticket Implementation](https://www.superconductor.com/tickets/khttKPgMkJkM/implementations/Rq7H6JpbLpg9) | [Guided Review](https://www.superconductor.com/tickets/khttKPgMkJkM/implementations/Rq7H6JpbLpg9?tab=guided_review)

<!-- created-by-superconductor -->