### PR TITLE
Update MD picture sizing from the original docx manual

### DIFF
--- a/01-blocks-scripts-and-sprites.md
+++ b/01-blocks-scripts-and-sprites.md
@@ -15,7 +15,7 @@ interface familiar to computer users.
 Start Snap<em>!</em>. You should see the following
 arrangement of {index}`regions <layout, window>` in the window:
 
-![An annotated screenshot of blank Snap! editor](images/12-user-interface-elements/snap-ide-annotated.png)
+{img alt="An annotated screenshot of blank Snap! editor" width="4.5in"}`images/12-user-interface-elements/snap-ide-annotated.png`
 
 (The proportions of these areas may be different, depending on the size
 and shape of your browser window.)
@@ -28,7 +28,7 @@ script
 :::
 
 (fig-draw-square)=
-![image6.png](images/01-blocks-scripts-and-sprites/image6.png)
+{img alt="image6.png" width="1.48in"}`images/01-blocks-scripts-and-sprites/image6.png`
 
 The five {index}`blocks <block>` that make up this script have three different colors,
 corresponding to three of the eight *palettes* in which blocks
@@ -46,11 +46,11 @@ is near the tab of the one above it:
 ::::{grid} 2
 
 :::{grid-item}
-![image7.png](images/01-blocks-scripts-and-sprites/image7.png)
+{img alt="image7.png" width="2.25in"}`images/01-blocks-scripts-and-sprites/image7.png`
 :::
 
 :::{grid-item}
-![image8.png](images/01-blocks-scripts-and-sprites/image8.png)
+{img alt="image8.png" width="2.21in"}`images/01-blocks-scripts-and-sprites/image8.png`
 :::
 ::::
 
@@ -129,7 +129,7 @@ In the sample script
 :::
 
 :::{grid-item}
-![image6.png](images/01-blocks-scripts-and-sprites/image6.png)
+{img alt="image6.png" width="1.48in"}`images/01-blocks-scripts-and-sprites/image6.png`
 :::
 
 :::{grid-item}
@@ -137,7 +137,7 @@ the `repeat` block has two inputs: the number 4 and the script
 :::
 
 :::{grid-item}
-![image11.png](images/01-blocks-scripts-and-sprites/image11.png)
+{img alt="image11.png" width="1.41in"}`images/01-blocks-scripts-and-sprites/image11.png`
 :::
 ::::
 
@@ -148,11 +148,11 @@ command block:
 ::::{grid} 2
 
 :::{grid-item}
-![image12.png](images/01-blocks-scripts-and-sprites/image12.png)
+{img alt="image12.png" width="5.70in"}`images/01-blocks-scripts-and-sprites/image12.png`
 :::
 
 :::{grid-item}
-![image13.png](images/01-blocks-scripts-and-sprites/image13.png)
+{img alt="image13.png" width="5.70in"}`images/01-blocks-scripts-and-sprites/image13.png`
 :::
 ::::
 
@@ -164,11 +164,11 @@ the haloed blocks:
 ::::{grid} 2
 
 :::{grid-item}
-![image16.png](images/01-blocks-scripts-and-sprites/image16.png)
+{img alt="image16.png" width="5.50in"}`images/01-blocks-scripts-and-sprites/image16.png`
 :::
 
 :::{grid-item}
-![image17.png](images/01-blocks-scripts-and-sprites/image17.png)
+{img alt="image17.png" width="5.50in"}`images/01-blocks-scripts-and-sprites/image17.png`
 :::
 ::::
 
@@ -195,7 +195,7 @@ will wrap around existing blocks in a script, and only if that C-shaped
 slot is empty before wrapping. (You can fill the other slots by dragging
 blocks into the desired slot.)
 
-![image24.png](images/01-blocks-scripts-and-sprites/image24.png)
+{img alt="image24.png" width="2.31in"}`images/01-blocks-scripts-and-sprites/image24.png`
 
 :::{index} new sprite button
 sprite corral
@@ -218,11 +218,11 @@ scripting area:
 ::::{grid} 2
 
 :::{grid-item}
-![image26.png](images/01-blocks-scripts-and-sprites/image26.png)
+{img alt="image26.png" width="1.55in"}`images/01-blocks-scripts-and-sprites/image26.png`
 :::
 
 :::{grid-item}
-![image27.png](images/01-blocks-scripts-and-sprites/image27.png)
+{img alt="image27.png" width="1.54in"}`images/01-blocks-scripts-and-sprites/image27.png`
 :::
 ::::
 
@@ -235,11 +235,11 @@ scripts of a single sprite also. Try this example:
 ::::{grid} 2
 
 :::{grid-item}
-![image28.png](images/01-blocks-scripts-and-sprites/image28.png)
+{img alt="image28.png" width="1.73in"}`images/01-blocks-scripts-and-sprites/image28.png`
 :::
 
 :::{grid-item}
-![image29.png](images/01-blocks-scripts-and-sprites/image29.png)
+{img alt="image29.png" width="1.73in"}`images/01-blocks-scripts-and-sprites/image29.png`
 :::
 ::::
 
@@ -278,7 +278,7 @@ way is quicker if the file you want is visible on the desktop: Just drag
 the file onto the Snap<em>!</em> window. In any of these cases, the scripting
 area will be replaced by something like this:
 
-![image31.png](images/01-blocks-scripts-and-sprites/image31.png)
+{img alt="image31.png" width="1.77in"}`images/01-blocks-scripts-and-sprites/image31.png`
 
 Just above this part of the window is a set of three tabs: Scripts,
 Costumes, and Sounds. You’ll see that the Costumes
@@ -317,19 +317,19 @@ another sprite to run a script. Here’s a simple example:
 (fig-broadcast-dog)=
 ::::{grid} 4
 :::{grid-item}
-![image41.png](images/01-blocks-scripts-and-sprites/image41.png)
+{img alt="image41.png" width="0.57in"}`images/01-blocks-scripts-and-sprites/image41.png`
 :::
 
 :::{grid-item}
-![image42.png](images/01-blocks-scripts-and-sprites/image42.png)
+{img alt="image42.png" width="2.78in"}`images/01-blocks-scripts-and-sprites/image42.png`
 :::
 
 :::{grid-item}
-![image43.png](images/01-blocks-scripts-and-sprites/image43.png)
+{img alt="image43.png" width="1.24in"}`images/01-blocks-scripts-and-sprites/image43.png`
 :::
 
 :::{grid-item}
-![image44.png](images/01-blocks-scripts-and-sprites/image44.png)
+{img alt="image44.png" width="1.52in"}`images/01-blocks-scripts-and-sprites/image44.png`
 :::
 ::::
 
@@ -412,11 +412,11 @@ extended to its parts. Also, cloning the anchor (see Section @sec-permanent-and-
 will also clone all its parts.
 
 <!-- TODO: Figure w/caption -->
-![image56.png](images/01-blocks-scripts-and-sprites/image56.png)
+{img alt="image56.png" width="1.44in"}`images/01-blocks-scripts-and-sprites/image56.png`
 
-![image48.png](images/01-blocks-scripts-and-sprites/image48.png)
+{img alt="image48.png" width="4.88in"}`images/01-blocks-scripts-and-sprites/image48.png`
 
-![image49.png](images/01-blocks-scripts-and-sprites/image49.png)
+{img alt="image49.png" width="4.88in"}`images/01-blocks-scripts-and-sprites/image49.png`
 
 *Top: turning the part: the green arm. Bottom: turning the anchor, with
 the arm synchronous (left) and dangling (right).*
@@ -504,11 +504,11 @@ special hexagonal input slots like this one:
 The C-shaped `if` block runs its input script if (and only
 if) the expression in its hexagonal input reports true.
 
-![image87.png](images/01-blocks-scripts-and-sprites/image87.png)
+{img alt="image87.png" width="1.59in"}`images/01-blocks-scripts-and-sprites/image87.png`
 
 A really useful block in animations runs its input script *repeatedly* until a predicate
 is satisfied:
-![image89.png](images/01-blocks-scripts-and-sprites/image89.png)
+{img alt="image89.png" width="2.29in"}`images/01-blocks-scripts-and-sprites/image89.png`
 
 If, while working on a project, you want to omit temporarily some commands
 in a script, but you don’t want to forget where they belong, you can say
@@ -750,7 +750,7 @@ containing a lot of data removed from memory before saving the project.
 To do this, right-click or control-click on the orange oval in the
 Variables palette, to see this menu:
 
-![image114.png](images/01-blocks-scripts-and-sprites/image114.png)
+{img alt="image114.png" width="1.29in"}`images/01-blocks-scripts-and-sprites/image114.png`
 
 You already know about the rename options, and "help…" displays a help
 screen about variables in general. Here we’re interested in the check
@@ -801,7 +801,7 @@ The `pause all` block turns bright cyan while paused. Also, during the pause, yo
 a running script and the menu that appears will give you the option to
 show watchers for temporary variables of the script:
 
-![image118.png](images/01-blocks-scripts-and-sprites/image118.png)
+{img alt="image118.png" width="1.88in"}`images/01-blocks-scripts-and-sprites/image118.png`
 
 But what if the block with the error is run many times in a loop, and it
 only errors when a particular condition is true — for example, when the value of some
@@ -928,7 +928,7 @@ sprite’s position before using it, and sometimes you need to know how
 big the text turned out to be, in turtle steps.) If the pen is down, the
 text will be underlined.
 
-{inline alt="image138.png"}`images/01-blocks-scripts-And-sprites/image138`
+{inline alt="image138.png"}`images/01-blocks-scripts-and-sprites/image138`
 Takes a sprite as input. Like stamp except that the costume is stamped onto the selected sprite instead of onto the stage. (Does nothing if the current sprite doesn’t overlap the chosen sprite.)
 
 {inline alt="image139.png"}`images/01-blocks-scripts-and-sprites/image139`
@@ -1049,7 +1049,7 @@ Similarly, these hidden predicates can be found by relabeling the relational pre
 
 ### Metaprogramming (see @sec-ch11)
 
-![image172.png](images/01-blocks-scripts-and-sprites/image172.png)
+{img alt="image172.png" width="0.88in"}`images/01-blocks-scripts-and-sprites/image172.png`
 
 These blocks support *metaprogramming,* which means manipulating blocks
 and scripts as data. This is not the same as manipulating procedures
@@ -1064,7 +1064,7 @@ of block (operators)
 ### First class list blocks (see @sec-ch04):
 
 <!-- TODO: welp. this needs to be remade -->
-![image173.png](images/01-blocks-scripts-and-sprites/image173.png)
+{img alt="image173.png" width="0.85in"}`images/01-blocks-scripts-and-sprites/image173.png`
 
 `Numbers from` will
 count up or down.
@@ -1078,16 +1078,16 @@ vector (x,y).
 :::
 
 **First class procedure blocks (see @sec-ch06):**
- ![image226.png](images/01-blocks-scripts-and-sprites/image226.png)
+ {img alt="image226.png" width="5.99in"}`images/01-blocks-scripts-and-sprites/image226.png`
 
 **First class continuation blocks (see @sec-ch10):**
- ![image227.png](images/01-blocks-scripts-and-sprites/image227.png)
+ {img alt="image227.png" width="5.99in"}`images/01-blocks-scripts-and-sprites/image227.png`
 
 **First class sprite, costume, and sound blocks (see @sec-ch07):**
 
- ![image228.png](images/01-blocks-scripts-and-sprites/image228.png)
+ {img alt="image228.png" width="5.99in"}`images/01-blocks-scripts-and-sprites/image228.png`
 
- ![image229.png](images/01-blocks-scripts-and-sprites/image229.png)
+ {img alt="image229.png" width="5.99in"}`images/01-blocks-scripts-and-sprites/image229.png`
 
 Object is a hyperblock.
 
@@ -1123,7 +1123,7 @@ two-item (x,y) lists
 to block
 :::
 
-![image283.png](images/01-blocks-scripts-and-sprites/image283.png)
+{img alt="image283.png" width="3.13in"}`images/01-blocks-scripts-and-sprites/image283.png`
 
 “Center” means the center of the stage, the
 point at (0,0). “Direction” is in the point in direction sense, the
@@ -1181,7 +1181,7 @@ set background block
 The {inline alt="length of text block"}`./blocks/images/block_reportTextAttribute` name was changed to clarify it is different from {inline alt="length of text block"}`./blocks/images/block_reportListAttribute`
 <!-- ::: -->
 
-![image308.png](images/01-blocks-scripts-and-sprites/image308.png)
+{img alt="image308.png" width="1.42in"}`images/01-blocks-scripts-and-sprites/image308.png`
 
 `+` and `×` are *variadic*: they take two or more inputs. If
 you drop a list on the arrowheads, the block name
@@ -1258,7 +1258,7 @@ is a grayscale value 0-255; a two-number list, grayscale plus opacity
 
 <!-- TODO: Images like this should have index entries defined after this image. -->
 (sec-pen-hue-block-options)=
-![image358.png](images/01-blocks-scripts-and-sprites/image358.png)
+{img alt="image358.png" width="2.41in"}`images/01-blocks-scripts-and-sprites/image358.png`
 
 :::{index} `of` block (sensing)
 `ask and wait` block
@@ -1268,13 +1268,13 @@ is a grayscale value 0-255; a two-number list, grayscale plus opacity
 ### Using Lists with the Ask Block
 These ask features and more in the Menus
 library.
-![image359.png](images/01-blocks-scripts-and-sprites/image359.png)
+{img alt="image359.png" width="0.60in"}`images/01-blocks-scripts-and-sprites/image359.png`
 
 ![image360.png](images/01-blocks-scripts-and-sprites/image360.png)
 
 ![image361.png](images/01-blocks-scripts-and-sprites/image361.png)
 
-![image362.png](images/01-blocks-scripts-and-sprites/image362.png)
+{img alt="image362.png" width="4.55in"}`images/01-blocks-scripts-and-sprites/image362.png`
 
 ::::{grid} 2
 
@@ -1316,7 +1316,7 @@ project, choose the Libraries… option in the
 file ({inline alt="file menu icon"}`images/01-blocks-scripts-and-sprites/image384`) menu.
 
 
-![The import libraries dialog](images/01-blocks-scripts-and-sprites/image385.png)
+{img alt="The import libraries dialog" width="3.27in"}`images/01-blocks-scripts-and-sprites/image385.png`
 
 <!-- TODO: This is out of date. It is somewhat redudant with chapter 12. -->
 The library menu is divided into five broad categories. The first is,
@@ -1484,7 +1484,7 @@ of numbers.
 The **word and sentence library** has these blocks:
 
 <!-- TODO: Index Entries for all these blocks -->
-![image394.png](images/01-blocks-scripts-and-sprites/image394.png)
+{img alt="image394.png" width="1.68in"}`images/01-blocks-scripts-and-sprites/image394.png`
 
 This library has the goal of recreating the Logo approach to handling text:
 A text isn’t best viewed as a string of characters, but rather as a *sentence*, made of *words*,
@@ -1747,11 +1747,11 @@ basic set of ten colors:
 :::{index} set pen to crayon block
 :::
 
-![image440.png](images/01-blocks-scripts-and-sprites/image440.png)
+{img alt="image440.png" width="4.37in"}`images/01-blocks-scripts-and-sprites/image440.png`
 
 Using `change pen crayon by` 5 instead gives ten more colors, for a total of 20:
 
-![image441.png](images/01-blocks-scripts-and-sprites/image441.png)
+{img alt="image441.png" width="4.36in"}`images/01-blocks-scripts-and-sprites/image441.png`
 
 (Why didn’t we use the colors of the 100-crayon Crayola™ box? A few
 reasons, one of which is that some Crayola colors aren’t representable
@@ -1768,13 +1768,13 @@ without the rest of the colors package.
 :::{index} crayon library
 :::
 
-![image442.png](images/01-blocks-scripts-and-sprites/image442.png)
+{img alt="image442.png" width="1.51in"}`images/01-blocks-scripts-and-sprites/image442.png`
 
 The catch errors library has these blocks:
 :::{index} catch errors library
 :::
 
-![image444.png](images/01-blocks-scripts-and-sprites/image444.png)
+{img alt="image444.png" width="3.04in"}`images/01-blocks-scripts-and-sprites/image444.png`
 
 The `safely try` block
  allows you to handle errors that happen when
@@ -1885,7 +1885,7 @@ The bignums, rationals, complex \#s library has these blocks:
 :::{index} library; infinite precision integers
 :::
 
-![image454.png](images/01-blocks-scripts-and-sprites/image454.png)
+{img alt="image454.png" width="1.88in"}`images/01-blocks-scripts-and-sprites/image454.png`
 
 The `USE BIGNUMS` block takes a Boolean input, to turn
 the infinite precision feature on or off. When on, all of the arithmetic
@@ -2023,7 +2023,7 @@ The web services library has these blocks:
 :::{index} web services library
 :::
 
-![image471.png](images/01-blocks-scripts-and-sprites/image471.png)
+{img alt="image471.png" width="3.41in"}`images/01-blocks-scripts-and-sprites/image471.png`
 
 The first block is a generalization of the primitive
 {index}`\`url\` block<`url` block>` , allowing more control over the various
@@ -2040,7 +2040,7 @@ single: `key\:value\:` block
 
 The {index}`database library` contains these blocks:
 
-![image472.png](images/01-blocks-scripts-and-sprites/image472.png)
+{img alt="image472.png" width="2.26in"}`images/01-blocks-scripts-and-sprites/image472.png`
 
 It is used to keep data that persist from one Snap<em>!</em> session
 to the next, if you use the same browser and the same login.
@@ -2070,9 +2070,9 @@ allows things like satellite pictures.
 
 The {index}`APL primitives library` contains these blocks:
 
-![image474.png](images/01-blocks-scripts-and-sprites/image474.png)
+{img alt="image474.png" width="5.73in"}`images/01-blocks-scripts-and-sprites/image474.png`
 
-![image475.png](images/01-blocks-scripts-and-sprites/image475.png)
+{img alt="image475.png" width="6.45in"}`images/01-blocks-scripts-and-sprites/image475.png`
 
 For more information about APL, see @sec-apl-features).
 
@@ -2080,7 +2080,7 @@ The **list comprehension library** has one block, `zip`:
 :::{index} list comprehension library
 :::
 
-![image476.png](images/01-blocks-scripts-and-sprites/image476.png)
+{img alt="image476.png" width="1.20in"}`images/01-blocks-scripts-and-sprites/image476.png`
 
 Its first input is a function of two inputs. The two Any-type inputs are
 deep lists (lists of lists of…) interpreted as trees, and the function
@@ -2105,7 +2105,7 @@ don’t already know what these mean, find a tutorial online.
 :::{index} bitwise library
 :::
 
-![image477.png](images/01-blocks-scripts-and-sprites/image477.png)
+{img alt="image477.png" width="0.89in"}`images/01-blocks-scripts-and-sprites/image477.png`
 
 The **MQTT library** supports the Message Queuing
 Telemetry Transport protocol, for connecting with IOT devices. See
@@ -2113,7 +2113,7 @@ Telemetry Transport protocol, for connecting with IOT devices. See
 :::{index} MQTT library, library; MQTTqq
 :::
 
-![image487.png](images/01-blocks-scripts-and-sprites/image487.png)
+{img alt="image487.png" width="3.55in"}`images/01-blocks-scripts-and-sprites/image487.png`
 
 The **Signada library** allows you to control a
 microBit or similar device that works with the Signada MicroBlocks
@@ -2121,7 +2121,7 @@ project.
 :::{index} Signada library
 :::
 
-![image488.png](images/01-blocks-scripts-and-sprites/image488.png)
+{img alt="image488.png" width="1.23in"}`images/01-blocks-scripts-and-sprites/image488.png`
 
 The **menus library** provides the ability to
 display hierarchical menus on the stage, using the ask block’s ability
@@ -2137,7 +2137,7 @@ TuneScope library
 :::
 
 ### Extensions Libraries
-![image486.png](images/01-blocks-scripts-and-sprites/image486.png)
+{img alt="image486.png" width="3.39in"}`images/01-blocks-scripts-and-sprites/image486.png`
 
 The **SciSnap<em>!</em> library** and the
 **TuneScope library** are too big to discuss here and are

--- a/02-saving-and-loading-projects-and.md
+++ b/02-saving-and-loading-projects-and.md
@@ -18,7 +18,7 @@ like if you save locally. This is why we have multiple ways to save.
 In either case, if you choose "`Save as…`" from the File menu. You’ll see something like this:
 
 (fig-saveas)=
-![image487.png](images/02-saving-and-loading-projects-and/image487.png)
+{img alt="image487.png" width="3.55in"}`images/02-saving-and-loading-projects-and/image487.png`
 <!--  style="width:3.54861in;height:2.57639in" / -->
 
 (If you are not logged in to your Snap<em>!</em> cloud account, Computer will
@@ -50,7 +50,7 @@ us. Click on the {index}`Cloud button` ({inline alt="image489.png"}`images/02-sa
 Choose the “`Signup…`” option. This will show you a window that looks like
 the picture below:
 
-![image488.png](images/02-saving-and-loading-projects-and/image488.png) <!--  style="width:1.23403in;height:2.32986in" / -->
+{img alt="image488.png" width="1.23in"}`images/02-saving-and-loading-projects-and/image488.png`
 
 You must choose a {index}`user name` that will identify you on
 the web site, such as `Jens`. If you’re a Scratch user, you can use
@@ -92,7 +92,7 @@ us say this.)
 Once you’ve created your account, you can log into it using the "`Login…`"
 option from the Cloud menu:
 
-![image490.png](images/02-saving-and-loading-projects-and/image490.png) <!--  style="width:1.6875in;height:2.02778in" / -->
+{img alt="image490.png" width="1.69in"}`images/02-saving-and-loading-projects-and/image490.png`
 
 Use the user name and password that you set up earlier. If you check the
 "`Stay signed in`" box, then you will be logged in automatically the next

--- a/03-building-a-block.md
+++ b/03-building-a-block.md
@@ -40,10 +40,10 @@ all sprites, or only to the current sprite and its children.
 
 In this dialog box, you can choose the block's palette, shape, and name.
 With one exception, there is one color per
-palette, e.g., all {span .mono}[Motion] blocks are blue. But the {span .mono}[Variables] palette
+palette, e.g., all {span .mono}`Motion` blocks are blue. But the {span .mono}`Variables` palette
 includes the orange variable-related blocks and the red list-related
 blocks. Both colors are available, along with an "`Other`" option that
-makes grey blocks in the {span .mono}[Variables] palette for blocks that don’t fit any
+makes grey blocks in the {span .mono}`Variables` palette for blocks that don’t fit any
 category.
 
 There are three block shapes , following a
@@ -55,7 +55,7 @@ Predicates, which is the technical term for reporters that report
 Boolean (true or false) values.
 
 Suppose you want to make a block named “square” that draws a square. You
-would choose {span .mono}[Motion], Command, and type “square” into the name field.
+would choose {span .mono}`Motion`, Command, and type “square” into the name field.
 When you click "`OK`", you enter the {index}`Block Editor`.
 This works just like making a script in the sprite’s scripting area,
 except that the “hat” block at the top, instead of saying something like
@@ -68,7 +68,7 @@ custom block, then click OK:
 
 {img alt="image503.png" width="4.62in"}`images/03-building-a-block/image503.png`
 
-Your block appears at the bottom of the {span .mono}[Motion] palette. Here’s the block
+Your block appears at the bottom of the {span .mono}`Motion` palette. Here’s the block
 and the result of using it:
 
 {img alt="image524.png" width="4.20in"}`images/03-building-a-block/image524.png`
@@ -109,7 +109,7 @@ You can now drag the orange variable down into the script, then click okay:
 
 {img alt="image511.png" width="1.47in"}`images/03-building-a-block/image511.png`
 
-Your block now appears in the {span .mono}[Motion] palette with an input box: ![image512.png](images/03-building-a-block/image512.png) <!--  style="width:0.69792in;height:0.25in" / --> You can draw
+Your block now appears in the {span .mono}`Motion` palette with an input box: ![image512.png](images/03-building-a-block/image512.png) <!--  style="width:0.69792in;height:0.25in" / --> You can draw
 any size square by entering the length of its side in the box and
 running the block as usual, by clicking it or by putting it in a script.
 
@@ -236,11 +236,11 @@ The window shows all of your
 global custom blocks. You can uncheck some of the checkboxes to select
 exactly which blocks you want to include in your library. (You can
 "`right-click`" or "`control-click`" on the export window for a menu that lets
-you check or uncheck all the boxes at once.) Then press "`OK`" An {span .mono}[XML] file
+you check or uncheck all the boxes at once.) Then press "`OK`" An {span .mono}`XML` file
 containing the blocks will appear in your Downloads location.
 
 To import a block library, use the "`Import…`" command in the "`File`" menu,
-or just drag the {span .mono}[XML] file into the Snap<em>!</em> window.
+or just drag the {span .mono}`XML` file into the Snap<em>!</em> window.
 
 Several block libraries are included with Snap<em>!</em>; for details about
 them, see @sec-libraries.

--- a/03-building-a-block.md
+++ b/03-building-a-block.md
@@ -29,14 +29,14 @@ In every palette, at or near the bottom, is a button labeled "`Make a block`" . 
 is a plus sign (+). Also, the menu you get by right-clicking on the
 background of the scripting area has a "`make a block`" option.
 
-![image523.png](images/03-building-a-block/image523.png)
+{img alt="image523.png" width="2.84in"}`images/03-building-a-block/image523.png`
 
 Clicking any of these will
 display a dialog window in which you choose the block’s name, shape, and
 palette/color. You also decide whether the block will be available to
 all sprites, or only to the current sprite and its children.
 
-![image501.png](images/03-building-a-block/image501.png) <!--  style="width:2.27083in;height:2.34722in" / -->
+{img alt="image501.png" width="2.27in"}`images/03-building-a-block/image501.png`
 
 In this dialog box, you can choose the block's palette, shape, and name.
 With one exception, there is one color per
@@ -64,14 +64,14 @@ except that the “hat” block at the top, instead of saying something like
 of your custom block.[^3] You drag blocks under the hat to program your
 custom block, then click OK:
 
-![image502.png](images/03-building-a-block/image502.png) <!--  style="width:4.21094in;height:1.3364in" / -->
+{img alt="image502.png" width="4.21in"}`images/03-building-a-block/image502.png`
 
-![image503.png](images/03-building-a-block/image503.png) <!--  style="width:4.61556in;height:3.64778in" / -->
+{img alt="image503.png" width="4.62in"}`images/03-building-a-block/image503.png`
 
 Your block appears at the bottom of the {span .mono}[Motion] palette. Here’s the block
 and the result of using it:
 
-![image524.png](images/03-building-a-block/image524.png) <!--  style="width:2.27083in;height:2.34722in" / -->
+{img alt="image524.png" width="4.20in"}`images/03-building-a-block/image524.png`
 
 [^3]: This use of the word “prototype” is unrelated to the *prototyping
 object oriented programming* discussed later.
@@ -89,11 +89,11 @@ Editor will open. Notice the plus signs before and
 after the word square in the prototype block. If you hover the mouse
 over one, it lights up:
 
-![image508.png](images/03-building-a-block/image508.png) <!--  style="width:3.44444in;height:2.72222in" / -->
+{img alt="image508.png" width="3.44in"}`images/03-building-a-block/image508.png`
 
 Click on the plus on the right. You will then see the “input name” dialog :
 
-![image509.png](images/03-building-a-block/image509.png) <!--  style="width:2.58333in;height:1.60417in" / -->
+{img alt="image509.png" width="2.58in"}`images/03-building-a-block/image509.png`
 
 Type in the name “size” and click "`OK`" There are other options in this
 dialog; you can choose "`title text`" if you want to
@@ -103,11 +103,11 @@ dialog with a lot of options about your input name. But we’ll leave that
 for later. When you click OK, the new input appears in the block
 prototype:
 
-![image510.png](images/03-building-a-block/image510.png) <!--  style="width:1.47917in;height:1.48958in" / -->
+{img alt="image510.png" width="1.48in"}`images/03-building-a-block/image510.png`
 
 You can now drag the orange variable down into the script, then click okay:
 
-![image511.png](images/03-building-a-block/image511.png) <!--  style="width:1.47472in;height:1.4955in" / -->
+{img alt="image511.png" width="1.47in"}`images/03-building-a-block/image511.png`
 
 Your block now appears in the {span .mono}[Motion] palette with an input box: ![image512.png](images/03-building-a-block/image512.png) <!--  style="width:0.69792in;height:0.25in" / --> You can draw
 any size square by entering the length of its side in the box and
@@ -132,7 +132,7 @@ the palette) and then change the category.)
 
 If you "`right-click/control-click`" the hat block, you get this menu:
 
-![image513.png](images/03-building-a-block/image513.png) <!--  style="width:0.99931in;height:0.76042in" / -->
+{img alt="image513.png" width="1.00in"}`images/03-building-a-block/image513.png`
 
 "`Script pic`" exports a picture of the script. (Many of
 the illustrations in this manual were made that way.) "`Translations`" opens a window in which you can specify how
@@ -210,7 +210,7 @@ entire toplevel script that called it.)
 
 Here’s a slightly more compact way to write the <code>factorial</code> function:
 
-![image521.png](images/03-building-a-block/image521.png) <!--  style="width:4.29167in;height:0.86458in" / -->
+{img alt="image521.png" width="4.29in"}`images/03-building-a-block/image521.png`
 
 For more on recursion, see *Thinking Recursively* by {index}`Eric Roberts<single: Roberts, Eric>`. (The originaledition is ISBN 978‑0471816522; a more recent *Thinking Recursively in
 Java* is ISBN 978-0471701460.) <!-- Do we want to link to something like https://books.google.com/books/about/Thinking_Recursively.html?id=oH9QAAAAMAAJ&source=kp_book_description --MF -->
@@ -230,7 +230,7 @@ game. Such a collection of blocks is called a *block library.*
 To create a block library, choose "`Export blocks…`" from the
 "`File`" menu. You then see a window like this:
 
-![image522.png](images/03-building-a-block/image522.png) <!--  style="width:2.02153in;height:2.72222in" / -->
+{img alt="image522.png" width="2.02in"}`images/03-building-a-block/image522.png`
 
 The window shows all of your
 global custom blocks. You can uncheck some of the checkboxes to select

--- a/04-first-class-lists.md
+++ b/04-first-class-lists.md
@@ -534,18 +534,30 @@ The major new feature in Snap<em>!</em> 6.0 is that the domain and range of
 most scalar function blocks is extended to multi-dimensional
 lists, with the underlying scalar function applied termwise:
 
-{img alt="Hyperblock addition: `(list 7 8 1) + (list 40 20 30)` returns the list 47, 28, 31 (termwise sum)." width="3.34in}  ![Hyperblock exponent: `2^ of (list 7 8 1)` returns the list 128, 256, 2.](images/04-first-class-lists/35-script-hyperblock-2-to-the-n.png){width=2.56in}  ![Hyperblock multiplication on two-row tables: `(list (list 7 8 1) (list 40 20 30)) × (list (list 3 5 4) (list 6 10 20))` returns a 2×3 table of termwise products (21, 40, 4 / 240, 200, 600).](images/04-first-class-lists/36-script-hyperblock-multiply-table.png){width=4.94in"}`images/04-first-class-lists/34-script-hyperblock-list-plus-list.png`
+::::{grid} 3
+:::{grid-item}
+{img alt="Hyperblock addition: `(list 7 8 1) + (list 40 20 30)` returns the list 47, 28, 31 (termwise sum)." width="3.34in"}`images/04-first-class-lists/34-script-hyperblock-list-plus-list.png`
+:::
+:::{grid-item}
+{img alt="Hyperblock exponent: `2^ of (list 7 8 1)` returns the list 128, 256, 2." width="2.56in"}`images/04-first-class-lists/35-script-hyperblock-2-to-the-n.png`
+:::
+:::{grid-item}
+{img alt="Hyperblock multiplication on two-row tables: `(list (list 7 8 1) (list 40 20 30)) × (list (list 3 5 4) (list 6 10 20))` returns a 2×3 table of termwise products (21, 40, 4 / 240, 200, 600)." width="4.94in"}`images/04-first-class-lists/36-script-hyperblock-multiply-table.png`
+:::
+::::
+
 Mathematicians, note in the last example above that the result is just a termwise
 application of the underlying function (7×3, 8×5, etc.), *not* matrix
-multiplication. See @sec-apl-features for that. For a dyadic (two-input) function, if the lengths don’t agree, the length of the result (in each
-dimension) is the length of the shorter input:
+multiplication. See @sec-apl-features for that. For a dyadic (two-input) function, if the lengths don’t agree, the length of the result (in each dimension) is the length of the shorter input:
 
 {img alt="Hyperblock multiplication where the two operands have rows of unequal length: the result is the size of the shorter input in each dimension, leaving the third column of column C empty in row 1." width="5.74in"}`images/04-first-class-lists/37-script-hyperblock-mismatched-lengths.png`
+
 However, if the *number of dimensions* differs in the two inputs, then the number of
 dimensions in the result agrees with the *higher-*dimensional input; the
 lower-dimensional one is used repeatedly in the missing dimension(s):
 
 {img alt="Hyperblock multiplication where one operand is a 2-D table and the other is a 1-D list: the 1-D list is broadcast across each row of the higher-dimensional input." width="6.79in"}`images/04-first-class-lists/38-script-hyperblock-mismatched-dimensions.png`
+
 (7×6, 8×10, 1×20, *40*×*6*, *20*×*10*, etc.). In particular, a *scalar*
 input is paired with every scalar in the other input:
 
@@ -558,7 +570,8 @@ Each pixel of the result has ¾ of its original red and green, and three times
 its original blue (with its transparency unchanged). By putting some
 sliders on the stage, you can play with colors dynamically:
 
-{img alt="A `forever` loop with `switch to costume ((pixels of costume alonzo) × (list red green blue 100) / 100)`, multiplying each pixel by current values of the red/green/blue stage variables." width="5.19in}![Three on-stage sliders labelled red (23), green (69), blue (277), next to a recoloured blue Alonzo sprite.](images/04-first-class-lists/42-watcher-rgb-sliders-alonzo.png){width=1.69in"}`images/04-first-class-lists/41-script-color-slider-loop.png`
+{inline alt="A `forever` loop with `switch to costume ((pixels of costume alonzo) × (list red green blue 100) / 100)`, multiplying each pixel by current values of the red/green/blue stage variables." width="5.19in"}`images/04-first-class-lists/41-script-color-slider-loop.png` {inline alt="Three on-stage sliders labelled red (23), green (69), blue (277), next to a recoloured blue Alonzo sprite." width="1.69in"}`images/04-first-class-lists/42-watcher-rgb-sliders-alonzo.png`
+
 There are a few naturally scalar functions that have already had specific
 meanings when applied to lists and therefore are not hyperblocks: `=` and
 `identical to` (because they compare entire structures, not just scalars,

--- a/04-first-class-lists.md
+++ b/04-first-class-lists.md
@@ -127,7 +127,7 @@ users will be familiar with the *imperative* programming
 style , which is based on a set of
 command blocks that modify a list:
 
-{inline alt="The four imperative list-mutation blocks: `add thing to`, `delete 1 of`, `insert thing at 1 of`, and `replace item 1 of with thing`." class="image-4x width=3.5in"}`images/04-first-class-lists/6-blocks-imperative-list-mutators.png`
+{img alt="The four imperative list-mutation blocks: `add thing to`, `delete 1 of`, `insert thing at 1 of`, and `replace item 1 of with thing`." class="image-2x" width="3.5in"}`images/04-first-class-lists/6-blocks-imperative-list-mutators.png`
 
 As an example, here are two blocks that take a list of numbers as input,
 and report a new list containing only the even numbers from the original

--- a/04-first-class-lists.md
+++ b/04-first-class-lists.md
@@ -262,7 +262,8 @@ them into one word, combine them into a sentence (with spaces between
 items), see if all items of a list of Booleans are true, see if any of
 the items is true, find the smallest, or find the largest.
 
-![A `combine (list 7 8 1) using (() + ())` reporter that returns 16.](images/04-first-class-lists/20-script-combine-sum.png){width=3.87in}
+{img alt="A `combine (list 7 8 1) using (() + ())` reporter that returns 16." width="3.87in"}`images/04-first-class-lists/20-script-combine-sum.png`
+
 {img alt="A `combine (list Yakko Wakko Dot) using (join () , ())` reporter that returns the string "Yakko,Wakko,Dot"." width="6.28in"}`images/04-first-class-lists/21-script-combine-join.png`
 Why `+` but not `−`? It only
 makes sense to combine list items using an *associative*
@@ -430,8 +431,19 @@ Ringo,Starr,drums
 
 Here’s what the corresponding table looks like:
 
-![The four-row Beatles CSV imported as a list named "band" and shown in table view: rows 1–4 hold first name, last name, and instrument across three columns.](images/04-first-class-lists/30-watcher-table-view-beatles.png){width=2.4in}
-{img alt="The same "band" list shown in list view: each row is a separate sublist of three items (first name, last name, instrument), stacked vertically." width="1.6in"}`images/04-first-class-lists/31-watcher-list-view-beatles.png`
+::::{grid} 2
+
+:::{grid-item}
+{img alt="The four-row Beatles CSV imported as a list named 'band' and shown in table view: rows 1–4 hold first name, last name, and instrument across three columns." width="2.4in"}`images/04-first-class-lists/30-watcher-table-view-beatles.png`
+
+:::
+
+:::{grid-item}
+{img alt="The same 'band' list shown in list view: each row is a separate sublist of three items (first name, last name, instrument), stacked vertically." width="1.6in"}`images/04-first-class-lists/31-watcher-list-view-beatles.png`
+:::
+
+::::
+
 Here’s how to read a spreadsheet into Snap<em>!</em>:
 
 1. Make a variable with a watcher on stage: {inline alt="A `my database` variable watcher initialised with the value 0." width="1.21in"}`images/04-first-class-lists/32-watcher-my-database.png`

--- a/04-first-class-lists.md
+++ b/04-first-class-lists.md
@@ -45,8 +45,7 @@ that’s ﬁrst class, not an individual value. Don’t think, for example,
 that some lists are ﬁrst class, while others aren’t. In Snap<em>!</em>, lists
 are ﬁrst class, period.
 
-![Snap! banner reading "Everything first class," with Alonzo waving beside the logo.](images/04-first-class-lists/1-banner-everything-first-class.png){width=2.84in}
-
+{img alt="Snap! banner reading "Everything first class," with Alonzo waving beside the logo." width="2.84in"}`images/04-first-class-lists/1-banner-everything-first-class.png`
 :::{index} anonymous list
 `list` block
 arrowheads
@@ -59,7 +58,7 @@ At the heart of providing first class lists is the ability to make an
 “anonymous” list —to make a list without
 simultaneously giving it a name. The `list` reporter block does that.
 
-{inline alt="The `list` reporter block, shown empty as it appears in the Variables palette, then filled with the words "She Loves You," then with a nested list and the number 41 (showing items can be of mixed types), and finally with the left arrowhead clicked to leave it empty." class="image-4x width=2.84in"}`images/04-first-class-lists/2-block-list.png`
+{inline alt="The `list` reporter block, shown empty as it appears in the Variables palette, then filled with the words "She Loves You," then with a nested list and the number 41 (showing items can be of mixed types), and finally with the left arrowhead clicked to leave it empty." class="image-4x" width="2.84in"}`images/04-first-class-lists/2-block-list.png`
 
 At the right end of the block are two left-and-right arrowheads.
 Clicking on these changes the number of inputs to
@@ -68,8 +67,7 @@ Shift-clicking changes by three at a time.
 
 You can use this block as input to many other blocks:
 
-![Examples of the `list` block being used as input to other blocks: a `say` block speaking the list, a `length of` reporter returning 3, and a `vowel?` predicate that uses `list a e i o u` as input to `contains`.](images/04-first-class-lists/3-script-list-as-input.png){width=5.79in}
-
+{img alt="Examples of the `list` block being used as input to other blocks: a `say` block speaking the list, a `length of` reporter returning 3, and a `vowel?` predicate that uses `list a e i o u` as input to `contains`." width="5.79in"}`images/04-first-class-lists/3-script-list-as-input.png`
 Snap<em>!</em> does not have a “`Make a list`” button like the one in Scratch.
 If you want a global “named list,” make a global variable and use the `set` block to put
 a list into the variable.
@@ -87,8 +85,7 @@ binary tree
 Lists can be inserted as elements in larger lists. We can easily create ad hoc structures as
 needed:
 
-![A list of four sublists pairing the Beatles' first and last names, with its watcher rendered as a 4-row, 2-column table view.](images/04-first-class-lists/4-script-lists-of-lists-beatles.png){width=5.89in}
-
+{img alt="A list of four sublists pairing the Beatles' first and last names, with its watcher rendered as a 4-row, 2-column table view." width="5.89in"}`images/04-first-class-lists/4-script-lists-of-lists-beatles.png`
 Notice that this list is presented in a different format from the “She
 Loves You” list above. A two-dimensional list is called a *table* and is
 by default shown in *table view.* We’ll have more to say about this
@@ -104,8 +101,7 @@ tree s with selectors that check for input of the
 correct data type; only one selector is shown but the ones for left and
 right children are analogous.
 
-![Two custom block definitions: a `binary tree` constructor that reports `list "binary-tree" datum left right`, and a `bt-datum` selector that checks the input is a tagged binary-tree list before returning item 2, otherwise saying that the input isn't a binary tree.](images/04-first-class-lists/5-script-binary-tree-block-defs.png){width=5.89in}
-
+{img alt="Two custom block definitions: a `binary tree` constructor that reports `list "binary-tree" datum left right`, and a `bt-datum` selector that checks the input is a tagged binary-tree list before returning item 2, otherwise saying that the input isn't a binary tree." width="5.89in"}`images/04-first-class-lists/5-script-binary-tree-block-defs.png`
 :::{index} Scratch
 imperative programming style
 parallelism
@@ -135,8 +131,7 @@ list:[^primitives]
 
 [^primitives]: Note to users of earlier versions: From the beginning, there has been a tension in our work between the desire to provide tools such as `for` (used in this example) and the higher order functions introduced on the next page as primitives, to be used as easily as other primitives, and the desire to show how readily such tools can be implemented in Snap! itself. This is one instance of our general pedagogic understanding that learners should both use abstractions and be permitted to see beneath the abstraction barrier. Until version 5.0, we used the uneasy compromise of a library of tools written in Snap! and easily, but not easily enough, loaded into a project. By not loading the tools, users or teachers could explore how to program them. In 5.0 we made them true primitives, partly because that’s what some of us wanted all along and partly because of the increasing importance of fast performance as we explore “big data” and media computation. In version 10.0 we introduced “hybrid” primitives, implemented in high speed Javascript but with an “Edit” option that will open, not the primitive implementation, but the version written in Snap<em>!</em>. This gives us editable primitives without dramatically slowing users’ projects.
 
-![Two imperative `evens` block definitions side by side. Each builds a `result` list and walks the input with `for index` or `for each item`, using `if (item mod 2) = 0` and `add ... to result` to collect even numbers, then reports `result`.](images/04-first-class-lists/7-script-evens-imperative.png){width=5.89in}
-
+{img alt="Two imperative `evens` block definitions side by side. Each builds a `result` list and walks the input with `for index` or `for each item`, using `if (item mod 2) = 0` and `add ... to result` to collect even numbers, then reports `result`." width="5.89in"}`images/04-first-class-lists/7-script-evens-imperative.png`
 In these scripts, we first create a temporary variable, then put an empty
 list in it, then go through the items of the input list using the `add
 ... to (result)` block to modify the result list, adding one item at a
@@ -153,7 +148,7 @@ parallelism, though, functional programming is sometimes a simpler
 and more effective technique, especially when dealing with recursively defined data
 structures. It uses reporter blocks, not command blocks, to build up a list value:
 
-{inline alt="The three functional list reporters used to build new lists without mutation: `in front of`, `item 1 of`, and `all but first of`." class="image-4x width=3in"}`images/04-first-class-lists/8-blocks-functional-list.png`
+{img alt="The three functional list reporters used to build new lists without mutation: `in front of`, `item 1 of`, and `all but first of`." class="image-4x" width="3in"}`images/04-first-class-lists/8-blocks-functional-list.png`
 
 In a functional program, we often use recursion to construct a list, one
 item at a time. The `in front of` block makes a
@@ -162,8 +157,7 @@ changing the value of the original list.* A nonempty list is processed
 by dividing it into its first item (`item 1 of` )
 and all the rest of the items (`all but first of` ), which are handled through a recursive call:
 
-![A recursive functional `evens` block definition. If `data` is empty, report the empty list. Otherwise, if `item 1 of data mod 2 = 0`, report `item 1 of data` in front of `evens (all but first of data)`; else recurse on `evens (all but first of data)`.](images/04-first-class-lists/9-script-evens-recursive.png){width=4.75in}
-
+{img alt="A recursive functional `evens` block definition. If `data` is empty, report the empty list. Otherwise, if `item 1 of data mod 2 = 0`, report `item 1 of data` in front of `evens (all but first of data)`; else recurse on `evens (all but first of data)`." width="4.75in"}`images/04-first-class-lists/9-script-evens-recursive.png`
 Snap<em>!</em> uses two different internal representations of lists, one (dynamic
 array) for imperative programming and the other (linked list)
 for functional programming. Each representation
@@ -184,8 +178,7 @@ higher order function
 
 There’s an even easier way to select the even numbers from a list:
 
-![A `keep items (() mod 2 = 0) from (list 9 4 7 2 0)` reporter, with the resulting list watcher showing items 4, 2, 0.](images/04-first-class-lists/10-script-keep-evens.png){width=4.75in}
-
+{img alt="A `keep items (() mod 2 = 0) from (list 9 4 7 2 0)` reporter, with the resulting list watcher showing items 4, 2, 0." width="4.75in"}`images/04-first-class-lists/10-script-keep-evens.png`
 The `keep` block takes a Predicate expression as its first input, and a list
 as its second input. It reports a list containing those elements of the
 input list for which the predicate returns `true`. Notice two things about
@@ -196,27 +189,24 @@ predicate. (The empty input is supposed to remind you of the “box”
 notation for variables in elementary school: 🔳+3=7.) The grey ring is
 part of the `keep` block as it appears in the palette:
 
-![The `keep items () from ()` block as it appears in the palette, with an empty grey ring around its first input.](images/04-first-class-lists/11-block-keep.png){width=2.38in}
-
+{img alt="The `keep items () from ()` block as it appears in the palette, with an empty grey ring around its first input." width="2.38in"}`images/04-first-class-lists/11-block-keep.png`
 What the ring means is that this input is a block (a predicate block, in
 this case, because the interior of the ring is a hexagon), rather than
 the value reported by that block. Here’s the difference:
 
-![On the left, the predicate `2 = 3` reporting `false`. On the right, the same predicate wrapped in a grey ring, which reports the block itself rather than its value.](images/04-first-class-lists/12-diagram-equals-with-ring.png){width=4.5in}
-
+{img alt="On the left, the predicate `2 = 3` reporting `false`. On the right, the same predicate wrapped in a grey ring, which reports the block itself rather than its value." width="4.5in"}`images/04-first-class-lists/12-diagram-equals-with-ring.png`
 Evaluating the `=` block without a ring reports `true` or `false`; evaluating
 the block *with* a ring reports the block itself. This allows `keep` to
 evaluate the `=` predicate repeatedly, once for each list item. A block
 that takes another block as input is called a *higher order* block (or
 higher order procedure, or higher order function ).
 
-![A diagram contrasting `map` (each input shape is replaced with a corresponding output shape), `keep` (each shape is either preserved or struck through), and `combine` (all shapes are folded together into a single result).](images/04-first-class-lists/13-diagram-map-keep-combine.png){width=4.5in}
-
+{img alt="A diagram contrasting `map` (each input shape is replaced with a corresponding output shape), `keep` (each shape is either preserved or struck through), and `combine` (all shapes are folded together into a single result)." width="4.5in"}`images/04-first-class-lists/13-diagram-map-keep-combine.png`
 
 Snap<em>!</em> provides four higher order function blocks for operating on
 lists:
 
-{inline alt="The four higher-order list blocks: `map () over ()`, `keep items () from ()`, `find first item () in ()`, and `combine () using ()`." class="image-4x width=2.5in"}`images/04-first-class-lists/14-blocks-higher-order.png`
+{img alt="The four higher-order list blocks: `map () over ()`, `keep items () from ()`, `find first item () in ()`, and `combine () using ()`." class="image-4x" width="2.5in"}`images/04-first-class-lists/14-blocks-higher-order.png`
 
 :::{index} `find first` block
 `map` block
@@ -234,7 +224,7 @@ associative function
 You’ve already seen `keep`. `Find first` is
 similar, but it reports just the first item that
 satisfies the predicate, not a list of all the matching items. It’s
-equivalent to {inline alt="item 1 of (keep items () from ())" class="image-inline width=1.6in"}`images/04-first-class-lists/15-script-find-first-equivalent.png` but faster because it
+equivalent to {inline alt="item 1 of (keep items () from ())" width="1.6in"}`images/04-first-class-lists/15-script-find-first-equivalent.png` but faster because it
 stops looking as soon as it finds a match. If there are no matching
 items, it returns an empty string.
 
@@ -243,14 +233,12 @@ reports a new list in which each item is the value reported by the
 Reporter block as applied to one item from the input list. That’s a
 mouthful, but an example will make its meaning clear:
 
-![A `map (() × 10) over (list 7 8 1)` reporter producing the list 70, 80, 10.](images/04-first-class-lists/16-script-map-times-10.png){width=2.6in}
-
+{img alt="A `map (() × 10) over (list 7 8 1)` reporter producing the list 70, 80, 10." width="2.6in"}`images/04-first-class-lists/16-script-map-times-10.png`
 By the way, we’ve been using arithmetic examples, but the list items can
 be of any type, and any reporter can be used. We’ll make the plurals of
 some words:
 
-![A `map (join () s) over (list book computer bagel)` reporter producing books, computers, bagels.](images/04-first-class-lists/17-script-map-plurals.png){width=2.7in}
-
+{img alt="A `map (join () s) over (list book computer bagel)` reporter producing books, computers, bagels." width="2.7in"}`images/04-first-class-lists/17-script-map-plurals.png`
 These examples use small lists, to fit the page, but the higher order
 blocks work for any size list.
 
@@ -261,24 +249,21 @@ lists, the result is a new toplevel list whose items are the same
 (uncopied) lists that are items of the toplevel input list). To make a deep copy of a list
 (that is, one in which all the sublists,
 sublists of sublists, etc. are copied), use the list as input to the
-{inline alt="the `id of` reporter" class="image-4x .image-inline width=0.74in"}`images/04-first-class-lists/18-block-id-of.png`  block (one of the variants
-of the `sqrt of` block). This works because `id of` is a @sec-hyperblock.
+{inline alt="the `id of` reporter" class="image-4x image-inline" width="0.74in"}`images/04-first-class-lists/18-block-id-of.png` block (one of the variants of the `sqrt of` block). This works because `id of` is a @sec-hyperblock.
 
 The third higher order block, `combine` , computes a
 single result from *all* the items of a list, using a *two-input*
 reporter as its second input. In practice, there are only a few blocks
 you’ll ever use with `combine`:
 
-![Eight reporter blocks commonly used as the function input to `combine`: `+`, `×`, `join`, `join words`, `and`, `or`, `min`, and `max`.](images/04-first-class-lists/19-blocks-combine-functions.png){width=6.5in}
-
+{img alt="Eight reporter blocks commonly used as the function input to `combine`: `+`, `×`, `join`, `join words`, `and`, `or`, `min`, and `max`." width="6.5in"}`images/04-first-class-lists/19-blocks-combine-functions.png`
 These blocks take the sum of the list items, take their product, string
 them into one word, combine them into a sentence (with spaces between
 items), see if all items of a list of Booleans are true, see if any of
 the items is true, find the smallest, or find the largest.
 
 ![A `combine (list 7 8 1) using (() + ())` reporter that returns 16.](images/04-first-class-lists/20-script-combine-sum.png){width=3.87in}
-![A `combine (list Yakko Wakko Dot) using (join () , ())` reporter that returns the string "Yakko,Wakko,Dot".](images/04-first-class-lists/21-script-combine-join.png){width=6.28in}
-
+{img alt="A `combine (list Yakko Wakko Dot) using (join () , ())` reporter that returns the string "Yakko,Wakko,Dot"." width="6.28in"}`images/04-first-class-lists/21-script-combine-join.png`
 Why `+` but not `−`? It only
 makes sense to combine list items using an *associative*
 function: one that doesn’t care in what order the items are combined (left to
@@ -295,8 +280,7 @@ item’s value (as usual), the item’s position in the input list (its
 index), and the entire input list. No more than three input names can be
 used in this context.
 
-![Advanced-mode `map` whose function input has three named parameters (value, index, list); applied to `list now here after math`, it joins each item to its position+1 to produce nowhere, hereafter, aftermath, math.](images/04-first-class-lists/22-script-map-three-input-names.png){width=5.81in}
-
+{img alt="Advanced-mode `map` whose function input has three named parameters (value, index, list); applied to `list now here after math`, it joins each item to its position+1 to produce nowhere, hereafter, aftermath, math." width="5.81in"}`images/04-first-class-lists/22-script-map-three-input-names.png`
 :::{index} table view
 list view
 :::
@@ -306,7 +290,7 @@ We mentioned earlier that there are two ways of representing lists
 visually. For one-dimensional lists (lists whose items are not
 themselves lists) the visual differences are small:
 
-{inline alt="The same 250-item list shown as a watcher in list view (left, with delete and add buttons) and table view (right, flatter cells)." class="image-4x width=3in"}`images/04-first-class-lists/23-watcher-list-vs-table-view.png`
+{img alt="The same 250-item list shown as a watcher in list view (left, with delete and add buttons) and table view (right, flatter cells)." class="image-4x" width="3in"}`images/04-first-class-lists/23-watcher-list-vs-table-view.png`
 
 For one-dimensional lists, it’s not really the appearance that’s
 important. What matters is that the *list view* allows very versatile
@@ -322,7 +306,7 @@ slow. As a partial workaround, the list view can only contain 100 items
 at a time; the downward-pointing arrowhead opens a menu in which you can
 choose which 100 to display.
 
-{inline alt="Bottom of a list view watcher with the paging menu open, showing the choices "1...", "101...", and "201..." for selecting which 100-item window to display." class="image-4x width=2in"}`images/04-first-class-lists/24-watcher-list-paging.png`
+{img alt="Bottom of a list view watcher with the paging menu open, showing the choices "1...", "101...", and "201..." for selecting which 100-item window to display." class="image-4x" width="2in"}`images/04-first-class-lists/24-watcher-list-paging.png`
 
 By contrast, because it doesn’t allow direct editing, the *table view*
 watcher can hold hundreds of thousands of items and still scroll through
@@ -345,8 +329,7 @@ the list has more than 100 items, or if any of the first ten items of
 the list are lists, in which case it makes a very different-looking
 two-dimensional picture:
 
-![A list of four sublists pairing the Beatles' first and last names, with its watcher rendered as a 4-row, 2-column table view.](images/04-first-class-lists/4-script-lists-of-lists-beatles.png){width=5.89in}
-
+{img alt="A list of four sublists pairing the Beatles' first and last names, with its watcher rendered as a 4-row, 2-column table view." width="5.89in"}`images/04-first-class-lists/4-script-lists-of-lists-beatles.png`
 In this format, the column of red items has been replaced by a
 spreadsheet-looking display. For short, wide lists, this display makes
 the content of the list very clear. A vertical display, with much of the
@@ -396,20 +379,17 @@ able to find out a column number by hovering over its letter.
 
 Any value that can appear in a program can be displayed in a table cell:
 
-![A list of five sublists pairing labels with values of different types — text, number, text, a `repeat 10` block, and the sprite "my self" — and the corresponding table view, where the block in row 4 is partially clipped by the standard cell size.](images/04-first-class-lists/26-watcher-table-with-block-cell.png){width=3.82in}
-
+{img alt="A list of five sublists pairing labels with values of different types — text, number, text, a `repeat 10` block, and the sprite "my self" — and the corresponding table view, where the block in row 4 is partially clipped by the standard cell size." width="3.82in"}`images/04-first-class-lists/26-watcher-table-with-block-cell.png`
 This display shows that the standard cell dimensions may not be enough
 for large value images. By expanding the entire speech balloon and then
 the second column and all the rows, we can make the result fit:
 
-![The same list-of-lists as the previous figure, but with the speech balloon, second column, and all rows enlarged so the embedded `repeat 10` block and Alonzo costume fit fully inside their cells.](images/04-first-class-lists/27-watcher-table-expanded-cells.png){width=3.34in}
-
+{img alt="The same list-of-lists as the previous figure, but with the speech balloon, second column, and all rows enlarged so the embedded `repeat 10` block and Alonzo costume fit fully inside their cells." width="3.34in"}`images/04-first-class-lists/27-watcher-table-expanded-cells.png`
 But we make an exception for cases in which the value in a cell is a list
 (so that the entire table is three-dimensional). Because lists are visually
 very big, we don’t try to fit the entire value in a cell:
 
-![A three-row list of [name, address, phone] sublists with the corresponding table view: the first column shows the labels and the second column shows small list icons rather than expanding the inner sublists.](images/04-first-class-lists/28-watcher-table-with-sublists.png){width=3.34in}
-
+{img alt="A three-row list of [name, address, phone] sublists with the corresponding table view: the first column shows the labels and the second column shows small list icons rather than expanding the inner sublists." width="3.34in"}`images/04-first-class-lists/28-watcher-table-with-sublists.png`
 Even if you expand the size of the cells, Snap<em>!</em> will not display
 sublists of sublists in table view. There are two ways to see these
 inner sublists: You can switch to list view, or you can double-click on
@@ -421,8 +401,7 @@ item of a list is a list (so table view is used), but a later item
 *isn’t* a list, that later item will be displayed on a red background,
 like an item of a single-column list:
 
-![A list whose first item is `list foo bar` and second item is the scalar "single"; the table view shows row 1 in two columns and row 2 with "single" rendered on a red background spanning the row.](images/04-first-class-lists/29-watcher-table-mixed.png){width=3.35in}
-
+{img alt="A list whose first item is `list foo bar` and second item is the scalar "single"; the table view shows row 1 in two columns and row 2 with "single" rendered on a red background spanning the row." width="3.35in"}`images/04-first-class-lists/29-watcher-table-mixed.png`
 So, in particular, if only the first item is a list, the display will
 look almost like a one-column display.
 
@@ -452,11 +431,10 @@ Ringo,Starr,drums
 Here’s what the corresponding table looks like:
 
 ![The four-row Beatles CSV imported as a list named "band" and shown in table view: rows 1–4 hold first name, last name, and instrument across three columns.](images/04-first-class-lists/30-watcher-table-view-beatles.png){width=2.4in}
-![The same "band" list shown in list view: each row is a separate sublist of three items (first name, last name, instrument), stacked vertically.](images/04-first-class-lists/31-watcher-list-view-beatles.png){width=1.6in}
-
+{img alt="The same "band" list shown in list view: each row is a separate sublist of three items (first name, last name, instrument), stacked vertically." width="1.6in"}`images/04-first-class-lists/31-watcher-list-view-beatles.png`
 Here’s how to read a spreadsheet into Snap<em>!</em>:
 
-1. Make a variable with a watcher on stage: {inline alt="A `my database` variable watcher initialised with the value 0." class="image-inline width=1.21in"}`images/04-first-class-lists/32-watcher-my-database.png`
+1. Make a variable with a watcher on stage: {inline alt="A `my database` variable watcher initialised with the value 0." width="1.21in"}`images/04-first-class-lists/32-watcher-my-database.png`
 
 <!-- The background of this picture should be transparent, not white. bh  -->
 
@@ -492,8 +470,7 @@ CSV format is easy to read, but works only for one- or two-dimensional
 lists. If you have a list of lists of lists, Snap<em>!</em> will instead export
 your list as a JSON (JavaScript Object Notation) file. I modified my list:
 
-![A `replace item 1 of (item 2 of band) with (list James Paul)` script that replaces "Paul" inside the second sublist with the two-name list ["James","Paul"].](images/04-first-class-lists/33-script-replace-item-band.png){width=6.33in}
-
+{img alt="A `replace item 1 of (item 2 of band) with (list James Paul)` script that replaces "Paul" inside the second sublist with the two-name list ["James","Paul"]." width="6.33in"}`images/04-first-class-lists/33-script-replace-item-band.png`
 and then exported again,
 getting this file:
 
@@ -545,37 +522,31 @@ The major new feature in Snap<em>!</em> 6.0 is that the domain and range of
 most scalar function blocks is extended to multi-dimensional
 lists, with the underlying scalar function applied termwise:
 
-![Hyperblock addition: `(list 7 8 1) + (list 40 20 30)` returns the list 47, 28, 31 (termwise sum).](images/04-first-class-lists/34-script-hyperblock-list-plus-list.png){width=3.34in}  ![Hyperblock exponent: `2^ of (list 7 8 1)` returns the list 128, 256, 2.](images/04-first-class-lists/35-script-hyperblock-2-to-the-n.png){width=2.56in}  ![Hyperblock multiplication on two-row tables: `(list (list 7 8 1) (list 40 20 30)) × (list (list 3 5 4) (list 6 10 20))` returns a 2×3 table of termwise products (21, 40, 4 / 240, 200, 600).](images/04-first-class-lists/36-script-hyperblock-multiply-table.png){width=4.94in}
-
+{img alt="Hyperblock addition: `(list 7 8 1) + (list 40 20 30)` returns the list 47, 28, 31 (termwise sum)." width="3.34in}  ![Hyperblock exponent: `2^ of (list 7 8 1)` returns the list 128, 256, 2.](images/04-first-class-lists/35-script-hyperblock-2-to-the-n.png){width=2.56in}  ![Hyperblock multiplication on two-row tables: `(list (list 7 8 1) (list 40 20 30)) × (list (list 3 5 4) (list 6 10 20))` returns a 2×3 table of termwise products (21, 40, 4 / 240, 200, 600).](images/04-first-class-lists/36-script-hyperblock-multiply-table.png){width=4.94in"}`images/04-first-class-lists/34-script-hyperblock-list-plus-list.png`
 Mathematicians, note in the last example above that the result is just a termwise
 application of the underlying function (7×3, 8×5, etc.), *not* matrix
 multiplication. See @sec-apl-features for that. For a dyadic (two-input) function, if the lengths don’t agree, the length of the result (in each
 dimension) is the length of the shorter input:
 
-![Hyperblock multiplication where the two operands have rows of unequal length: the result is the size of the shorter input in each dimension, leaving the third column of column C empty in row 1.](images/04-first-class-lists/37-script-hyperblock-mismatched-lengths.png){width=5.74in}
-
+{img alt="Hyperblock multiplication where the two operands have rows of unequal length: the result is the size of the shorter input in each dimension, leaving the third column of column C empty in row 1." width="5.74in"}`images/04-first-class-lists/37-script-hyperblock-mismatched-lengths.png`
 However, if the *number of dimensions* differs in the two inputs, then the number of
 dimensions in the result agrees with the *higher-*dimensional input; the
 lower-dimensional one is used repeatedly in the missing dimension(s):
 
-![Hyperblock multiplication where one operand is a 2-D table and the other is a 1-D list: the 1-D list is broadcast across each row of the higher-dimensional input.](images/04-first-class-lists/38-script-hyperblock-mismatched-dimensions.png){width=6.79in}
-
+{img alt="Hyperblock multiplication where one operand is a 2-D table and the other is a 1-D list: the 1-D list is broadcast across each row of the higher-dimensional input." width="6.79in"}`images/04-first-class-lists/38-script-hyperblock-mismatched-dimensions.png`
 (7×6, 8×10, 1×20, *40*×*6*, *20*×*10*, etc.). In particular, a *scalar*
 input is paired with every scalar in the other input:
 
-![Two examples of `letter` applied with hyperblock indices over the word "world": a flat list of indices returns the list d,r,o,l,l, and a list-of-lists of indices returns a 2×3 table of letters (l,o,w / r,o,d).](images/04-first-class-lists/39-script-hyperblock-letter-of-indices.png){width=7.48in}
-
+{img alt="Two examples of `letter` applied with hyperblock indices over the word "world": a flat list of indices returns the list d,r,o,l,l, and a list-of-lists of indices returns a 2×3 table of letters (l,o,w / r,o,d)." width="7.48in"}`images/04-first-class-lists/39-script-hyperblock-letter-of-indices.png`
 One important motivation for this feature is how it simplifies and speeds up media
 computation, as in this shifting of the Alonzo costume to be bluer:
 
-![A `new costume ((pixels of costume alonzo) × (list .75 .75 3 1)) width (current) height (current)` script and the resulting bluer Alonzo costume thumbnail.](images/04-first-class-lists/40-script-costume-color-shift.png){width=7.48in}
-
+{img alt="A `new costume ((pixels of costume alonzo) × (list .75 .75 3 1)) width (current) height (current)` script and the resulting bluer Alonzo costume thumbnail." width="7.48in"}`images/04-first-class-lists/40-script-costume-color-shift.png`
 Each pixel of the result has ¾ of its original red and green, and three times
 its original blue (with its transparency unchanged). By putting some
 sliders on the stage, you can play with colors dynamically:
 
-![A `forever` loop with `switch to costume ((pixels of costume alonzo) × (list red green blue 100) / 100)`, multiplying each pixel by current values of the red/green/blue stage variables.](images/04-first-class-lists/41-script-color-slider-loop.png){width=5.19in}![Three on-stage sliders labelled red (23), green (69), blue (277), next to a recoloured blue Alonzo sprite.](images/04-first-class-lists/42-watcher-rgb-sliders-alonzo.png){width=1.69in}
-
+{img alt="A `forever` loop with `switch to costume ((pixels of costume alonzo) × (list red green blue 100) / 100)`, multiplying each pixel by current values of the red/green/blue stage variables." width="5.19in}![Three on-stage sliders labelled red (23), green (69), blue (277), next to a recoloured blue Alonzo sprite.](images/04-first-class-lists/42-watcher-rgb-sliders-alonzo.png){width=1.69in"}`images/04-first-class-lists/41-script-color-slider-loop.png`
 There are a few naturally scalar functions that have already had specific
 meanings when applied to lists and therefore are not hyperblocks: `=` and
 `identical to` (because they compare entire structures, not just scalars,
@@ -584,9 +555,9 @@ don’t evaluate their second input at all if the first input determines
 the result), `join` (because it converts non-scalar (and other non-text)
 inputs to text string form), and `is a (type)` (because it applies to its
 input as a whole). Blocks whose inputs are “natively” lists, such as {inline alt="the `length of` reporter" class="image-4x .image-inline width=0.89in"}`images/04-first-class-lists/43-block-length-of.png` and
-{inline alt="the `in front of` reporter" class="image-inline width=1.03in"}`images/04-first-class-lists/44-block-in-front-of.png` , are never hyperblocks.
+{inline alt="the `in front of` reporter" width="1.03in"}`images/04-first-class-lists/44-block-in-front-of.png` , are never hyperblocks.
 
-{inline alt="the `reshape () to 4 3` reporter" class="image-inline width=2.10in"}`images/04-first-class-lists/45-block-reshape.png` The
+{inline alt="the `reshape () to 4 3` reporter" width="2.10in"}`images/04-first-class-lists/45-block-reshape.png` The
 `reshape` block\index{`reshape` block} takes a list (of any depth) as its
 first input, and then takes zero or more sizes along the dimensions of
 an array. In the example it will report a table (a matrix) of four rows
@@ -597,16 +568,15 @@ block starts again at the head of the list, using values more than once.
 If more values are provided than needed, the extras are ignored; this
 isn’t an error.
 
-{inline alt="the `combinations` reporter taking two list inputs" class="image-inline width=1.76in"}`images/04-first-class-lists/46-block-combinations.png`  The
+{inline alt="the `combinations` reporter taking two list inputs" width="1.76in"}`images/04-first-class-lists/46-block-combinations.png`  The
 `combinations` block takes any number of lists as input; it reports a list
 in which each item is a list whose length is the number of inputs; item
 *i* of a sublist is an item of input *i.* Every possible combination of
 items of the inputs is included, so the length of the reported list is
 the product of the lengths of the inputs.
 
-![A `combinations (list a b) (list x y z)` reporter and the resulting 6-row, 2-column table: a/x, a/y, a/z, b/x, b/y, b/z.](images/04-first-class-lists/47-script-combinations-example.png){width=5.24in}
-
-{inline alt="the `item 1 of` reporter" class="image-inline width=1.34in"}`images/04-first-class-lists/48-block-item-of.png`  The `item of` block has a special set of rules, designed to preserve
+{img alt="A `combinations (list a b) (list x y z)` reporter and the resulting 6-row, 2-column table: a/x, a/y, a/z, b/x, b/y, b/z." width="5.24in"}`images/04-first-class-lists/47-script-combinations-example.png`
+{inline alt="the `item 1 of` reporter" width="1.34in"}`images/04-first-class-lists/48-block-item-of.png`  The `item of` block has a special set of rules, designed to preserve
 its pre-hyperblock meaning and also provide a useful behavior when given
 a list as its first (index) input:
 
@@ -615,39 +585,33 @@ a list as its first (index) input:
     which case the entire sublist is reported (the original meaning of
     `item of`):
 
-    ![`item 3 of` the four-row Beatles list returns the sublist `George Harrison`.](images/04-first-class-lists/49-script-item-3-of-band.png){width=5.51in}
-
+    {img alt="`item 3 of` the four-row Beatles list returns the sublist `George Harrison`." width="5.51in"}`images/04-first-class-lists/49-script-item-3-of-band.png`
 2.  If the index is a list of numbers (no sublists), then `item of`
     reports a list of the indicated top-level items (rows, in a matrix;
     a straightforward hyperization):
-    ![`item (list 2 1 2) of` the Beatles list returns three rows: Paul/McCartney, John/Lennon, Paul/McCartney.](images/04-first-class-lists/50-script-item-list-of-band.png){width=6.01in}
-
+    {img alt="`item (list 2 1 2) of` the Beatles list returns three rows: Paul/McCartney, John/Lennon, Paul/McCartney." width="6.01in"}`images/04-first-class-lists/50-script-item-list-of-band.png`
 3.  If the index is a list of lists of numbers, then `item of` reports an
     array of only those scalars whose position in the list input matches
     the index input in all dimensions (as of Snap<em>!</em>
     6.6):
 
-    ![`item (list (list 4) (list 2 1)) of` the Beatles list selects row 4, columns 2 and 1, returning the single-row table `Starr Ringo`.](images/04-first-class-lists/51-script-item-nested-of-band.png){width=6.01in}
-
+    {img alt="`item (list (list 4) (list 2 1)) of` the Beatles list selects row 4, columns 2 and 1, returning the single-row table `Starr Ringo`." width="6.01in"}`images/04-first-class-lists/51-script-item-nested-of-band.png`
 4.  If a list of list of numbers includes an empty sublist, then all
     items are chosen along that
     dimension:
 
-    ![`item (list (list 4) (list)) of` the Beatles list — using an empty inner list as wildcard — returns all columns of row 4: Ringo Starr.](images/04-first-class-lists/52-script-item-empty-sublist-of-band.png){width=6.01in}
-
+    {img alt="`item (list (list 4) (list)) of` the Beatles list — using an empty inner list as wildcard — returns all columns of row 4: Ringo Starr." width="6.01in"}`images/04-first-class-lists/52-script-item-empty-sublist-of-band.png`
 To get a column or columns of a spreadsheet, use an empty list in the row
 selector (as of Snap<em>!</em> 6.6):
 
-![`item (list (list) (list 2 1 2)) of` the Beatles list selects every row across columns 2, 1, 2, producing a 4×3 table of last-names/first-names/last-names.](images/04-first-class-lists/53-script-item-column-of-spreadsheet.png){width=6.60in}
-
+{img alt="`item (list (list) (list 2 1 2)) of` the Beatles list selects every row across columns 2, 1, 2, producing a 4×3 table of last-names/first-names/last-names." width="6.60in"}`images/04-first-class-lists/53-script-item-column-of-spreadsheet.png`
 The `length of` block is extended to provide
 various ways of looking at the shape and contents of a list. The options
 other than `length` are mainly useful for *lists of lists,* to any depth.
 These new options work well with hyperblocks and the APL library.
 <!-- (Examples are on the next page.) -➞
 
-![The `length of` block with its dropdown menu open, showing the options: length, rank, dimensions, flatten, columns, reverse, lines, csv, json.](images/04-first-class-lists/54-block-length-of-dropdown.png){width=2.5in}
-
+{img alt="The `length of` block with its dropdown menu open, showing the options: length, rank, dimensions, flatten, columns, reverse, lines, csv, json." width="2.5in"}`images/04-first-class-lists/54-block-length-of-dropdown.png`
 - `length`: reports the number of (toplevel) items in the list, as always.
 
 - `rank` : reports the number of *dimensions* of the
@@ -685,8 +649,7 @@ of any rank; it reports a text string in which the list structure is
 explicitly represented using square brackets. These are the opposites of
 `split by csv` and `split by json`.
 
-![Each `length of` option applied to the same 4×3 table `[[1,2,3],[4,5,6],[7,8,9],[10,11,12]]`: length=4, rank=2, dimensions=[4,3], flatten=12-item flat list, columns=3×4 transpose, reverse=row-reversed table, plus the multi-line text outputs of lines, csv, and json.](images/04-first-class-lists/55-script-length-of-options-applied.png){width=6.60in}
-
+{img alt="Each `length of` option applied to the same 4×3 table `[[1,2,3],[4,5,6],[7,8,9],[10,11,12]]`: length=4, rank=2, dimensions=[4,3], flatten=12-item flat list, columns=3×4 transpose, reverse=row-reversed table, plus the multi-line text outputs of lines, csv, and json." width="6.60in"}`images/04-first-class-lists/55-script-length-of-options-applied.png`
 The idea of extending the domain and range of scalar functions to
 include arrays comes from the language APL. (All the great
 programming languages are based on mathematical ideas. Our primary

--- a/05-typed-inputs.md
+++ b/05-typed-inputs.md
@@ -33,11 +33,11 @@ Number type
 
 In the {index}`Block Editor` input name dialog, there is a right-facing arrowhead after the "`Input name`" option:
 
-![image692.png](images/05-typed-inputs/image692.png)
+{img alt="image692.png" width="3.67in"}`images/05-typed-inputs/image692.png`
 
 Clicking that arrowhead opens the “long” input name dialog:
 
-![image657.png](images/05-typed-inputs/image657.png)
+{img alt="image657.png" width="5.17in"}`images/05-typed-inputs/image657.png`
 
 There are twelve input type shapes, plus three mutually exclusive modifiers,
 listed in addition to the basic choice between title text and
@@ -53,7 +53,7 @@ each row of types is a category, and parts of each column form a
 category. Understanding the arrangement will make it a little easier to
 find the type you want.
 
-![image659.png](images/05-typed-inputs/image659.png) <!--  style="width:6.82222in;height:2.75694in" / -->
+{img alt="image659.png" width="6.82in"}`images/05-typed-inputs/image659.png`
 
 The second row of input types
 contains the ones found in Scratch: {span .mono}[Number], {span .mono}[Any], and {span .mono}[Boolean]. (The
@@ -111,7 +111,7 @@ this isn’t quite right for the C-shaped command input type, since
 commands don’t report values. But you’ll see
 later that it’s true in spirit.)
 
-![image660.png](images/05-typed-inputs/image660.png) <!--  style="width:3.64583in;height:3.11389in" / -->
+{img alt="image660.png" width="3.65in"}`images/05-typed-inputs/image660.png`
 
 :::{index} pulldown input
 read-only pulldown input
@@ -126,16 +126,16 @@ Certain primitive blocks have *pulldown* inputs,
 either *read-only*, like the input
 to the <code>is ( ) touching</code> block:
 
-![image661.png](images/05-typed-inputs/image661.png) <!--  style="width:1.68056in;height:0.94097in" / -->
+{img alt="image661.png" width="1.68in"}`images/05-typed-inputs/image661.png`
 
 (indicated by the input slot being the same (cyan, in this case) color as the body of the block), or *writeable*, like the input to the <code>point in direction ( )</code> block:
 
-![image662.png](images/05-typed-inputs/image662.png) <!--  style="width:1.90208in;height:1.32292in" / -->
+{img alt="image662.png" width="1.90in"}`images/05-typed-inputs/image662.png`
 
 (indicated by the white input slot), which means that the user can type
 in an arbitrary input instead of using the pulldown menu.
 
-![image663.png](images/05-typed-inputs/image663.png) <!--  style="width:0.83264in;height:0.65278in" / -->
+{img alt="image663.png" width="0.83in"}`images/05-typed-inputs/image663.png`
 
 Custom blocks can
 also have such inputs. To make a pulldown input, open the long form
@@ -147,7 +147,7 @@ Click
 the "`read-only`" checkbox if you want a read-only pulldown input. Then from
 the same menu, choose "`options…`" to get this dialog box:
 
-![image664.png](images/05-typed-inputs/image664.png) <!--  style="width:3.07639in;height:1.875in" / -->
+{img alt="image664.png" width="3.08in"}`images/05-typed-inputs/image664.png`
 
 Each line in the text box represents one menu item. If the line does not
 contain any of the characters "`=`", "`~`", or "`{}`" then the text is both what’s shown in
@@ -172,7 +172,7 @@ hovering the mouse over it displays the submenu next to the original
 menu. A line containing a close brace "`}`" ends the submenu; nothing else
 should be on that line. Submenus may be nested to arbitrary depth.
 
-![image693.png](images/05-typed-inputs/image693.png) <!--  style="width:3.07639in;height:1.875in" / -->
+{img alt="image693.png" width="0.50in"}`images/05-typed-inputs/image693.png`
 
 Alternatively, instead of giving a menu listing as described above, you
 can put a JavaScript function that returns the desired menu in the
@@ -189,7 +189,7 @@ text or "`code`" for monospace-font computer code.
 
 If the input type is something other than text, then clicking the {inline alt="image670.png" class="image-inline"}`images/05-typed-inputs/image670.png` <!--  style="width:0.13056in;height:0.1375in" --> button will instead show this menu:
 
-![image669.png](images/05-typed-inputs/image669.png) <!--  style="width:0.60417in;height:0.31944in" -->
+{img alt="image669.png" width="0.60in"}`images/05-typed-inputs/image669.png`
 
 As an example, we want to make this block: {inline alt="image671.png" class="image-inline"}`images/05-typed-inputs/image671.png` <!--  style="width:0.60417in;height:0.31944in" -->  The second input must be a read-only object menu:
 
@@ -217,9 +217,9 @@ slot in the palette, like the “10” in the <code>move (10) steps block</code>
 prototype block at the top of the script in the Block editor, an an input with
 name “size” and default value 10 looks like this:
 
-![image678.png](images/05-typed-inputs/image678.png) <!--  style="width:1.63889in;height:0.52083in" -->
+{img alt="image678.png" width="1.64in"}`images/05-typed-inputs/image678.png`
 
-![image679.png](images/05-typed-inputs/image679.png) <!--  style="width:1.76389in;height:0.93056in" / -->
+{img alt="image679.png" width="1.76in"}`images/05-typed-inputs/image679.png`
 
 The "`Multiple inputs`" option:
 The <code>list</code> block introduced earlier accepts any number of inputs to
@@ -244,7 +244,7 @@ than as an input slot. Here’s an example; the uparrow (**↑**)
 in the prototype indicates this kind of internal variable name:
 
 <!-- Referred to at the top of chapter 6. -->
-![Definition of `my for` block and the block created.](images/05-typed-inputs/image695.png)
+{img alt="Definition of `my for` block and the block created." width="7.07in"}`images/05-typed-inputs/image695.png`
 
 The variable <var>i</var> (in the block on the right above) can be dragged from the
 {index}`for block` into the blocks used in its C-shaped command
@@ -265,7 +265,7 @@ We have mentioned three notations that can appear in an input slot in
 the prototype to remind you of what kind of input this is. Here is the
 complete list of such notations:
 
-![image685.png](images/05-typed-inputs/image685.png) <!--  style="width:0.73472in;height:6.11806in" / -->
+{img alt="image685.png" width="0.73in"}`images/05-typed-inputs/image685.png`
 
 - = default value
 - … multiple input
@@ -289,7 +289,7 @@ the prototype at the point where you want to insert the symbol. Then
 click the "`title text`" picture below the text box that’s expecting an
 input slot name. The dialog will then change to look like this:
 
-![image689.png](images/05-typed-inputs/image689.png) <!--  style="width:2.03472in;height:1.26389in" / -->
+{img alt="image689.png" width="2.03in"}`images/05-typed-inputs/image689.png`
 
 The important part to notice is the arrowhead that has appeared at the right
 end of the text box. Click it to see the menu shown here at the left.
@@ -300,13 +300,13 @@ icons.
 
 But I’d like the arrow symbol bigger, and yellow, so I edit its name:
 
-![image690.png](images/05-typed-inputs/image690.png) <!--  style="width:2.03472in;height:1.26389in" / -->
+{img alt="image690.png" width="2.03in"}`images/05-typed-inputs/image690.png`
 
 This makes the symbol 1.5 times as big as the letters in the block text, using a color with
 red-green-blue values of 255-255-150 (each between 0 and 255). Here’s
 the result:
 
-![image691.png](images/05-typed-inputs/image691.png) <!--  style="width:1.19792in;height:0.27083in" / -->
+{img alt="image691.png" width="1.20in"}`images/05-typed-inputs/image691.png`
 
 The size and color controls can also be used with text: <code>$foo-8-255-120-0</code>
 will make a huge orange <code>foo</code>.

--- a/05-typed-inputs.md
+++ b/05-typed-inputs.md
@@ -10,13 +10,13 @@ data type
 
 ## Scratch’s Type Notation
 
-Prior to version 3, Scratch block inputs came in two types: {span .mono}[Text-or-number] type and {span .mono}[Number] type. The former is
+Prior to version 3, Scratch block inputs came in two types: {span .mono}`Text-or-number` type and {span .mono}`Number` type. The former is
 indicated by a rectangular box, the latter by a rounded box: {inline alt="image654.png" class="image-inline"}`images/05-typed-inputs/image654.png`. A third
-Scratch type, {span .mono}[Boolean] (true/false), can be used in certain {span .mono}[Control]
+Scratch type, {span .mono}`Boolean` (true/false), can be used in certain {span .mono}`Control`
 blocks with hexagonal slots.
 
-The Snap<em>!</em> types are an expanded collection including {span .mono}[Procedure], {span .mono}[List],
-and {span .mono}[Object] types. Note that, with the exception of {span .mono}[Procedure] types, all
+The Snap<em>!</em> types are an expanded collection including {span .mono}`Procedure`, {span .mono}`List`,
+and {span .mono}`Object` types. Note that, with the exception of {span .mono}`Procedure` types, all
 of the input type shapes are just reminders to the user of what the
 block expects; they are not enforced by the language.
 
@@ -56,31 +56,31 @@ find the type you want.
 {img alt="image659.png" width="6.82in"}`images/05-typed-inputs/image659.png`
 
 The second row of input types
-contains the ones found in Scratch: {span .mono}[Number], {span .mono}[Any], and {span .mono}[Boolean]. (The
+contains the ones found in Scratch: {span .mono}`Number`, {span .mono}`Any`, and {span .mono}`Boolean`. (The
 reason these are in the second row rather than the ﬁrst will become
 clear when we look at the column arrangement.) The ﬁrst row contains the
-new Snap<em>!</em> types other than procedures: {span .mono}[Object], {span .mono}[Text], and {span .mono}[List]. The last two rows are the types related to procedures, discussed more fully below.
+new Snap<em>!</em> types other than procedures: {span .mono}`Object`, {span .mono}`Text`, and {span .mono}`List`. The last two rows are the types related to procedures, discussed more fully below.
 
-The {span .mono}[List] type is used for ﬁrst class lists, discussed
+The {span .mono}`List` type is used for ﬁrst class lists, discussed
 in Chapter IV. The red rectangles inside the input slot are meant
 to resemble the appearance of lists as Snap<em>!</em> displays them on the
 stage: each element in a red rectangle.
 
-The {span .mono}[Object] type is for sprites, costumes, sounds,
+The {span .mono}`Object` type is for sprites, costumes, sounds,
 and similar data types.
 
-The {span .mono}[Text] type is really just a variant form of the Any
+The {span .mono}`Text` type is really just a variant form of the Any
 type, using a shape that suggests a text input.[^5]
 
-[^5]: In Scratch, every block that takes a {span .mono}[Text-type] input has a default
+[^5]: In Scratch, every block that takes a {span .mono}`Text-type` input has a default
 value that makes the rectangles for text wider than tall. The blocks
-that aren’t specifically about text either are of {span .mono}[Number] type
+that aren’t specifically about text either are of {span .mono}`Number` type
 or have no default value, so those rectangles are
-taller than wide. At ﬁrst some of us (bh) thought that {span .mono}[Text] was a
+taller than wide. At ﬁrst some of us (bh) thought that {span .mono}`Text` was a
 separate type that always had a wide input slot; it turns out that this
 isn’t true in Scratch (delete the default text and the rectangle
 narrows), but we thought it a good idea anyway, so we allow Text-shaped
-boxes even for empty input slots. (This is why {span .mono}[Text] comes just above {span .mono}[Any]
+boxes even for empty input slots. (This is why {span .mono}`Text` comes just above {span .mono}`Any`
 in the input type selection box.)
 
 :::{index} jigsaw-piece blocks
@@ -139,8 +139,8 @@ in an arbitrary input instead of using the pulldown menu.
 
 Custom blocks can
 also have such inputs. To make a pulldown input, open the long form
-input dialog, choose a text type ({span .mono}[Any], {span .mono}[Text], or {span .mono}[Number]) and click the {inline alt="image658.png"}`images/05-typed-inputs/image658.png` <!--  style="width:0.13194in;height:0.13194in" -->
-icon in the bottom right corner, or {span .mono}[control/right-click] in the dialog.
+input dialog, choose a text type ({span .mono}`Any`, {span .mono}`Text`, or {span .mono}`Number`) and click the {inline alt="image658.png"}`images/05-typed-inputs/image658.png` <!--  style="width:0.13194in;height:0.13194in" -->
+icon in the bottom right corner, or {span .mono}`control/right-click` in the dialog.
 You will see this menu:
 
 Click
@@ -211,7 +211,7 @@ type array.
 
 The "`single input`" option: In Scratch, all inputs are in this category.
 There is one input slot in the block as it appears in its palette. If a
-single input is of type {span .mono}[Any], {span .mono}[Number], {span .mono}[Text], or {span .mono}[Boolean], then you can
+single input is of type {span .mono}`Any`, {span .mono}`Number`, {span .mono}`Text`, or {span .mono}`Boolean`, then you can
 specify a {index}`default value` that will be shown in that
 slot in the palette, like the “10” in the <code>move (10) steps block</code>. In the
 prototype block at the top of the script in the Block editor, an an input with
@@ -225,7 +225,7 @@ The "`Multiple inputs`" option:
 The <code>list</code> block introduced earlier accepts any number of inputs to
 specify the items of the new list. To allow this, Snap<em>!</em> introduces the
 arrowhead notation (⏴⏵) that expands and contracts the block, adding and
-removing input slots. ({span .mono}[Shift-clicking] on an arrowhead adds or removes
+removing input slots. ({span .mono}`Shift-clicking` on an arrowhead adds or removes
 three input slots at once.) Custom blocks made by the Snap<em>!</em> user have
 that capability, too. If you choose the "`Multiple inputs`" button, then
 arrowheads will appear after the input slot in the

--- a/06-procedures-as-data.md
+++ b/06-procedures-as-data.md
@@ -4,7 +4,7 @@
 (sec-ch06)=
 # 6. Procedures as Data
 
-![Definition of `my for` block and the block created.](images/05-typed-inputs/image695.png)
+{img alt="Definition of `my for` block and the block created." width="7.07in"}`images/05-typed-inputs/image695.png`
 
 :::{index} call block
 first class procedures
@@ -19,7 +19,7 @@ In the {index}`for block` example above, the input named <var>action</var> has b
 does the block actually tell Snap<em>!</em> to carry out the commands inside
 the C-slot? Here is a simple version of the block script:
 
-![image692.png](images/06-procedures-as-data/image692.png)
+{img alt="image692.png" width="3.67in"}`images/06-procedures-as-data/image692.png`
 
 This is simplified because it assumes, without checking, that the ending
 value is greater than the starting value; if not, the block should
@@ -41,7 +41,7 @@ program.
 Here’s another example, this time using a Reporter-type input in a `map`
 block (see @sec-map):
 
-![image743.png](images/06-procedures-as-data/image743.png)
+{img alt="image743.png" width="0.97in"}`images/06-procedures-as-data/image743.png`
 
 Here we are calling the Reporter `multiply by (10)` three times, once with
 each item of the given list as its input, and collecting the results as
@@ -66,7 +66,7 @@ The `call` block (like the `run` block) has a right arrowhead at the end;
 clicking on it adds the phrase "`with inputs`" and then a slot into which
 an input can be inserted:
 
-![image698.png](images/06-procedures-as-data/image698.png) <!--  style="width:1.8125in;height:0.20833in" / -->
+{img alt="image698.png" width="1.81in"}`images/06-procedures-as-data/image698.png`
 
 If the left arrowhead is used to remove the last input slot, the "`with inputs`" disappears also. The right arrowhead can be
 clicked as many times as needed for the number of inputs required by the
@@ -93,7 +93,7 @@ input. If you want to use a block itself in a non-Reporter-type (e.g.,
 Any-type) input slot, you can enclose it explicitly in a ring, found at
 the top of the {span .mono}[Operators] palette.
 
-![image744.png](images/06-procedures-as-data/image744.png) <!--  style="width:0.5in;height:0.15625in" / -->
+{img alt="image744.png" width="1.08in"}`images/06-procedures-as-data/image744.png`
 
 As a shortcut, if you right-click or control-click on a block (such as
 the `( ) + ( ) ` block in this example), one of the choices in the menu that
@@ -165,7 +165,7 @@ just don’t usually think about it in those terms! We could write the
 repeat block as a custom block this way, if Snap<em>!</em>
 didn’t already have one:
 
-![image708.png](images/06-procedures-as-data/image708.png) <!--  style="width:2.375in;height:1.35417in" / -->
+{img alt="image708.png" width="2.38in"}`images/06-procedures-as-data/image708.png`
 
 The lambda ("`λ`") next to <var>action</var> in the prototype indicates that this is a
 C-shaped block, and that the script enclosed by
@@ -175,7 +175,7 @@ understand that its value is a script.
 
 To declare an input to be {span .mono}[Procedure-type], open the input name dialog as usual, and click on the arrowhead:
 
-![image509.png](images/06-procedures-as-data/image509.png) <!--  style="width:2.58333in;height:1.60417in" / -->
+{img alt="image509.png" width="2.58in"}`images/06-procedures-as-data/image509.png`
 
 Then, in the long dialog, choose the appropriate Procedure type. The
 third row of input types has a ring in the shape of each block type
@@ -191,7 +191,7 @@ block, it turns into an inline slot, as in the `repeater` block’s
 recursive call above. (Other built-in Reporters can’t report scripts, so
 they aren’t accepted in a C-shaped slot.)
 
- ![image709.png](images/06-procedures-as-data/image709.png) <!--  style="width:3.65278in;height:2.75455in" / -->
+ {img alt="image709.png" width="3.65in"}`images/06-procedures-as-data/image709.png`
 
 
 Why would you ever choose an inline Command slot rather than a C shape?
@@ -200,7 +200,7 @@ case I can think of is something like the C /C++/Java `for` loop, which
 actually has *three* command script inputs (and one predicate input),
 only one of which is the “featured” loop body:
 
-![image710.png](images/06-procedures-as-data/image710.png) <!--  style="width:2.11458in;height:0.46875in" / -->
+{img alt="image710.png" width="2.11in"}`images/06-procedures-as-data/image710.png`
 
 Okay, now that we have procedures as inputs to our blocks, how do we use
 them? We use the blocks `run` (for commands) and `call`
@@ -219,12 +219,12 @@ possible meanings:
 of inputs provided, then Snap<em>!</em> fills the empty slots from left to
 right:
 
-![image711.png](images/06-procedures-as-data/image711.png) <!--  style="width:3.44792in;height:0.34406in" / -->
+{img alt="image711.png" width="3.45in"}`images/06-procedures-as-data/image711.png`
 
 2. If exactly one input is provided, Snap<em>!</em> will fill any number of
 empty slots with it:
 
-![image712.png](images/06-procedures-as-data/image712.png) <!--  style="width:2.80208in;height:0.30694in" / -->
+{img alt="image712.png" width="2.80in"}`images/06-procedures-as-data/image712.png`
 
 3. Otherwise, Snap<em>!</em> won’t fill any slots, because the user’s
 intention is unclear.
@@ -258,7 +258,7 @@ drop that input list *onto the arrowheads* that indicate a
 variable-input slot, rather than onto the
 input slot:
 
-![image715.png](images/06-procedures-as-data/image715.png) <!--  style="width:2.27569in;height:1.59722in" / -->
+{img alt="image715.png" width="2.28in"}`images/06-procedures-as-data/image715.png`
 
 
 Note that the halo you see while dragging onto the
@@ -272,7 +272,7 @@ numbers, each individual item is a number, just what `sizes` wants. This
 block will take any number of numbers as inputs, and will make the
 sprite grow and shrink accordingly:
 
-![image716.png](images/06-procedures-as-data/image716.png)
+{img alt="image716.png" width="6.81in"}`images/06-procedures-as-data/image716.png`
 
 The user of this block calls it with any number of *individual numbers* as
 inputs. But inside the definition of the block, all of those numbers
@@ -282,7 +282,7 @@ it processes the ﬁrst input (`item (1) of ( )`the list), then it wants to make
 a recursive call with all but the ﬁrst number (`all but first of ( )`). But `sizes` doesn’t take a
 list as input; it takes numbers as inputs! So this would be wrong:
 
-![image722.png](images/06-procedures-as-data/image722.png)
+{img alt="image722.png" width="2.96in"}`images/06-procedures-as-data/image722.png`
 
 :::{index} name, input
 `#1`
@@ -317,7 +317,7 @@ example using explicit names to control which input goes where inside
 the `ring`:
 
 
-![image731.png](images/06-procedures-as-data/image731.png) <!--  style="width:4.32292in;height:0.45417in" / -->
+{img alt="image731.png" width="4.32in"}`images/06-procedures-as-data/image731.png`
 
 Here we just want to put one of the inputs into two different slots. If
 we left all three slots empty, Snap<em>!</em> would not fill any of them,
@@ -327,7 +327,7 @@ empty slots (3).
 Here is a more realistic,
 much more advanced example: ![image733.png](images/06-procedures-as-data/image733.png) <!--  style="width:4.34722in;height:1.40278in" / -->
 
-![image732.png](images/06-procedures-as-data/image732.png) <!--  style="width:4.67986in;height:3.01806in" / -->
+{img alt="image732.png" width="4.68in"}`images/06-procedures-as-data/image732.png`
 
 This is the definition of a block that takes any number of lists, and
 reports the list of all possible combinations of one item from each
@@ -358,7 +358,7 @@ an example of a situation in which a procedure must be explicitly marked
 as data by pulling a `ring` from the {span .mono}[Operators] palette and putting the
 procedure (block or script) inside it:
 
-![image734.png](images/06-procedures-as-data/image734.png) <!--  style="width:5.1875in;height:1.65625in" / -->
+{img alt="image734.png" width="5.19in"}`images/06-procedures-as-data/image734.png`
 
 Here, we are making a list of procedures.
 But the `list` block accepts inputs of any type, so its input slots are
@@ -372,7 +372,7 @@ are `set ( ) to ( )` (to set the value of a variable to a procedure), `say ( )`a
 (to display a procedure to the user), and `report ( )`(for a reporter that
 reports a procedure):
 
-![image735.png](images/06-procedures-as-data/image735.png) <!--  style="width:3.83333in;height:0.84375in" / -->
+{img alt="image735.png" width="3.83in"}`images/06-procedures-as-data/image735.png`
 
 :::{index} `if else` block
 factorial
@@ -394,18 +394,21 @@ emphasize functional programming, it lacks a corresponding reporter
 block to choose between two expressions. Snap<em>!</em> has one, but we could
 write our own:
 
-<!-- TODO: The 2 + 1 layout is kind of a special case. -->
-:::{.evenly-spaced-images layout-ncol=2}
-![image736.png](images/06-procedures-as-data/image736.png) <br/>
-![image739.png](images/06-procedures-as-data/image739.png)
+::::{grid} 2
+:::{grid-item}
+{img alt="image736.png" width="2.50in"}`images/06-procedures-as-data/image736.png`
 
-![image737.png](images/06-procedures-as-data/image737.png)
+{img alt="image739.png" width="3.82in"}`images/06-procedures-as-data/image739.png`
 :::
+:::{grid-item}
+{img alt="image737.png" width="2.40in"}`images/06-procedures-as-data/image737.png`
+:::
+::::
 
 Our block works for these simple examples, but if we try to use it in writing a
 {index}`recursive operator`, it’ll fail:
 
-![image738.png](images/06-procedures-as-data/image738.png) <!--  style="width:4.29167in;height:0.84861in" / -->
+{img alt="image738.png" width="4.29in"}`images/06-procedures-as-data/image738.png`
 
 The problem is that when any block is called, all of its inputs are
 computed (evaluated) before the block itself runs. The block itself
@@ -421,13 +424,17 @@ be of type {span .mono}[Reporter] rather than type {span .mono}[Any]. Then, when
 those inputs will be enclosed in a `ring` so that the expressions
 themselves, rather than their values, become the inputs:
 
-:::{.evenly-spaced-images layout-ncol=3}
-![image740.png](images/06-procedures-as-data/image740.png)
-
-![image742.png](images/06-procedures-as-data/image742.png)
-
-![image741.png](images/06-procedures-as-data/image741.png)
+::::{grid} 3
+:::{grid-item}
+{img alt="image740.png" width="1.11in"}`images/06-procedures-as-data/image740.png`
 :::
+:::{grid-item}
+{img alt="image742.png" width="2.62in"}`images/06-procedures-as-data/image742.png`
+:::
+:::{grid-item}
+{img alt="image741.png" width="4.52in"}`images/06-procedures-as-data/image741.png`
+:::
+::::
 
 In this version, the program works, with no infinite loop. But we’ve
 paid a heavy price: this `reporter-if` is no longer as intuitively obvious

--- a/06-procedures-as-data.md
+++ b/06-procedures-as-data.md
@@ -91,7 +91,7 @@ and `map` above. This notation indicates that *the block itself,* not the
 number or other value that the block would report when called, is the
 input. If you want to use a block itself in a non-Reporter-type (e.g.,
 Any-type) input slot, you can enclose it explicitly in a ring, found at
-the top of the {span .mono}[Operators] palette.
+the top of the {span .mono}`Operators` palette.
 
 {img alt="image744.png" width="1.08in"}`images/06-procedures-as-data/image744.png`
 
@@ -152,10 +152,10 @@ otherwise, “reporter” includes predicates. When the word is capitalized
 inside a sentence, it means specifically oval-shaped blocks. So, “nested
 reporters” includes predicates, but “a Reporter-type input” doesn’t.)
 
-Although an {span .mono}[Any-type] input slot (what you get if you use the small
+Although an {span .mono}`Any-type` input slot (what you get if you use the small
 input-name dialog box) will accept a procedure input, it doesn’t
 automatically ring the input as described above. So the declaration of
-{span .mono}[Procedure-type] inputs makes the use of your custom higher order block
+{span .mono}`Procedure-type` inputs makes the use of your custom higher order block
 much more convenient.
 
 Why would you want a block to take a procedure as input? This is actually
@@ -173,7 +173,7 @@ the C when the block is used is the input named <var>action</var> in the body of
 the script. The only way to make sense of the variable <var>action</var> is to
 understand that its value is a script.
 
-To declare an input to be {span .mono}[Procedure-type], open the input name dialog as usual, and click on the arrowhead:
+To declare an input to be {span .mono}`Procedure-type`, open the input name dialog as usual, and click on the arrowhead:
 
 {img alt="image509.png" width="2.58in"}`images/06-procedures-as-data/image509.png`
 
@@ -355,7 +355,7 @@ stop Snap<em>!</em> from filling a slot that should really remain empty.
 
 Here’s
 an example of a situation in which a procedure must be explicitly marked
-as data by pulling a `ring` from the {span .mono}[Operators] palette and putting the
+as data by pulling a `ring` from the {span .mono}`Operators` palette and putting the
 procedure (block or script) inside it:
 
 {img alt="image734.png" width="5.19in"}`images/06-procedures-as-data/image734.png`
@@ -420,7 +420,7 @@ an infinite loop. We need `my if then else` block to be able to select
 only one of the two alternatives to be evaluated.
 
 We have a mechanism to allow that: declare the then variable <var>yes</var> and else variable <var>no</var> inputs to
-be of type {span .mono}[Reporter] rather than type {span .mono}[Any]. Then, when calling the block,
+be of type {span .mono}`Reporter` rather than type {span .mono}`Any`. Then, when calling the block,
 those inputs will be enclosed in a `ring` so that the expressions
 themselves, rather than their values, become the inputs:
 
@@ -458,16 +458,16 @@ transformation of constant data into constant functions) is called a
 *special form*. To turn our `if` block into a
 special form, we edit the block’s prototype, declaring the inputs <var>yes</var>
 and <var>no</var> to be of type "`Any (unevaluated)`"
-instead of type {span .mono}[Reporter]. The script for the block is still that of the
+instead of type {span .mono}`Reporter`. The script for the block is still that of the
 second version, including the use of `call` to evaluate either <var>yes</var> or <var>no</var>
-but not both. But the slots appear as white {span .mono}[Any-type] rectangles, not
-{span .mono}[Reporter-type] rings, and the factorial block will look like our ﬁrst
+but not both. But the slots appear as white {span .mono}`Any-type` rectangles, not
+{span .mono}`Reporter-type` rings, and the factorial block will look like our ﬁrst
 attempt.
 
 In a special form’s prototype, {index}`the unevaluated`
 input slot(s) are indicated by a lambda ("`λ`") next to the input name, just
-as if they were declared as {span .mono}[Procedure] type. They
-*are* {span .mono}[Procedure] type, really; they’re just disguised to the user of the
+as if they were declared as {span .mono}`Procedure` type. They
+*are* {span .mono}`Procedure` type, really; they’re just disguised to the user of the
 block.
 
 Special forms trade off implementor sophistication
@@ -494,14 +494,14 @@ Scratch doesn’t have custom C‑shaped blocks, it can afford to handwave
 away the distinction between evaluated and unevaluated Booleans, but
 Snap<em>!</em> can’t. The pedagogic value of special forms is proven by the
 fact that no Scratcher ever notices that there’s anything strange about
-the way in which the hexagonal inputs in the {span .mono}[Control] blocks are
+the way in which the hexagonal inputs in the {span .mono}`Control` blocks are
 evaluated.
 
 Also, the C-shaped slot familiar to Scratch users
 is an unevaluated procedure type; you don’t have to use a `ring` to keep
 the commands in the C-slot from being run before the C-shaped block is
 run. Those commands themselves, not the result of running them, are the
-input to the C-shaped {span .mono}[Control] block. (This is taken for granted by
+input to the C-shaped {span .mono}`Control` block. (This is taken for granted by
 Scratch users, especially because Scratchers don’t think of the contents
 of a C-slot as an input at all.) This is why it makes sense that
 “C‑shaped” is on the fourth row of types in the long form input dialog,

--- a/07-object-oriented-programming-with-sprites.md
+++ b/07-object-oriented-programming-with-sprites.md
@@ -20,7 +20,7 @@ just more data) that you interact with by sending it a
 *message* (just a name, maybe in the form of a text string, and perhaps
 additional inputs). The object responds to the message by carrying out a
 method, which may or may not report a value back to the asker. Some
-people {index}`emphasize the` *data hiding* aspect of {span .mono}[OOP]
+people {index}`emphasize the` *data hiding* aspect of {span .mono}`OOP`
 (because each object has local variables that other objects can access
 only by sending request messages to the owning object) while others
 emphasize the *simulation* aspect (in which each object abstractly
@@ -29,7 +29,7 @@ the program model real interactions of real people or things). Data
 hiding is important for large multi-programmer industrial projects, but
 for Snap<em>!</em> users it’s the simulation aspect that’s
 important. Our approach is therefore less restrictive than that of some
-other {span .mono}[OOP] languages; we give objects easy access to each others’ data
+other {span .mono}`OOP` languages; we give objects easy access to each others’ data
 and methods.
 
 Technically, object oriented programming rests on three legs:
@@ -64,10 +64,10 @@ sprites. Each sprite can own local variables; each
 sprite has its own scripts (methods). A Scratch animation is plainly a
 simulation of the interaction of characters in a play. There are two
 ways in which Scratch sprites are less versatile than the objects of an
-{span .mono}[OOP]language. First, Scratch message passing is weak in three respects:
+{span .mono}`OOP`language. First, Scratch message passing is weak in three respects:
 Messages can only be <code>broadcast</code>, not addressed
 to an individual sprite; messages can’t take inputs; and methods can’t
-return values to their caller. Second, and more basic, in the {span .mono}[OOP]
+return values to their caller. Second, and more basic, in the {span .mono}`OOP`
 paradigm objects are *data;* they can be the value of a variable, an
 element of a list, and so on, but that’s not the case for Scratch
 sprites.
@@ -117,7 +117,7 @@ number of essentially identical sprites that behave like the example.
 copies any more. (As we’ll see, “copies” is the wrong word because the
 parent and the children *share* a lot of properties. That’s why we use
 the word “clones” to describe the children rather than “copies.”) These
-are *{span .mono}[temporary]* clones. They are automatically
+are *{span .mono}`temporary`* clones. They are automatically
 deleted when the user presses either the "`green flag`" or the "`red stop sign`". In Scratch 2.0 and later, all clones are
 temporary.
 
@@ -135,7 +135,7 @@ of <var>Cocker Spaniel</var> (so there are four altogether) and two clones of
 <var>Rottweiler</var>. Maybe you hide the <var>Dog</var> sprite after all this, since it’s no
 breed in particular. Each dog has its own position, special behaviors,
 and so on. You want to save all of these dogs in the project. These are
-*{span .mono}[permanent]* clones. In {span .mono}[BYOB 3.1], the
+*{span .mono}`permanent`* clones. In {span .mono}`BYOB 3.1`, the
 predecessor to Snap<em>!</em>, all clones are
 permanent.
 
@@ -195,7 +195,7 @@ continue without waiting. For this purpose we have the <code>launch ( )</code> b
 
 <code>Launch ( )</code> is analogous to <code>broadcast</code> without the “wait.”
 
-Snap<em>!</em> {span .mono}[4.1], following {span .mono}[BYOB 3.1], used an extension of the of block to
+Snap<em>!</em> {span .mono}`4.1`, following {span .mono}`BYOB 3.1`, used an extension of the of block to
 provide access to other sprites’ methods. That interface was designed
 back when we were trying hard to avoid adding new primitive blocks; it
 allowed us to write <code>ask ( ) and wait</code> and <code>tell ( )</code> as tool procedures in Snap<em>!</em> itself.
@@ -210,13 +210,13 @@ polymorphism
 
 ### Polymorphism
 
-Suppose you have a {span .mono}[Dog] sprite
-with two clones CockerSpaniel and PitBull. In the {span .mono}[Dog] sprite you define
+Suppose you have a {span .mono}`Dog` sprite
+with two clones CockerSpaniel and PitBull. In the {span .mono}`Dog` sprite you define
 this method ("`For this sprite only`" block):
 
 {img alt="image763.png" width="1.67in"}`images/07-object-oriented-programming-with-sprites/image763.png`
 
-Note the *loca*tion ({span .mono}[map-pin]) symbol before the
+Note the *loca*tion ({span .mono}`map-pin`) symbol before the
 block’s name. The symbol is not part of the block title; it’s a visual
 reminder that this is a sprite-*loca*l block. Sprite-local variables are
 similarly marked.
@@ -229,15 +229,15 @@ And here’s what a PitBull does:
 
 {img alt="image765.png" width="4.05in"}`images/07-object-oriented-programming-with-sprites/image765.png`
 
-<code>Greet ( )</code> is defined in the {span .mono}[Dog] sprite.
+<code>Greet ( )</code> is defined in the {span .mono}`Dog` sprite.
 If Fido is a particular cocker
 spaniel, and you ask Fido to <code>greet</code> someone, Fido inherits the <code>greet ( )</code>
-method from {span .mono}[Dog], but {span .mono}[Dog] itself couldn’t actually run that method,
-because {span .mono}[Dog] doesn’t have <code>greet ( ) as friend</code> or <code>greet ( ) as enemy</code>. And perhaps
+method from {span .mono}`Dog`, but {span .mono}`Dog` itself couldn’t actually run that method,
+because {span .mono}`Dog` doesn’t have <code>greet ( ) as friend</code> or <code>greet ( ) as enemy</code>. And perhaps
 only individual dogs such as Fido have <code>friend? ( )</code> methods. Even though the
-<code>greet ( )</code> method is defined in the {span .mono}[Dog] sprite, when it’s running it
+<code>greet ( )</code> method is defined in the {span .mono}`Dog` sprite, when it’s running it
 remembers what specific dog sprite called it, so it knows which <code>greet ( ) as
-friend</code> to use. {span .mono}[Dog]’s <code>greet ( )</code> block is called a *polymorphic* method,
+friend</code> to use. {span .mono}`Dog`’s <code>greet ( )</code> block is called a *polymorphic* method,
 because it means different things to different dogs, even though they
 all share the same script.
 
@@ -294,7 +294,7 @@ parent attribute
 
 ## Prototyping: Parents and Children
 
-Most current {span .mono}[OOP] languages use a *class/instance* approach to creating
+Most current {span .mono}`OOP` languages use a *class/instance* approach to creating
 objects. A class is a particular *kind of object,* and an instance is an
 *actual object* of that type. For example, there might be a Dog class,
 and several instances Fido, Spot, and Runt. The class typically
@@ -315,7 +315,7 @@ expressive system, because you can easily simulate a class/instance
 hierarchy by hiding the prototype sprite! Prototyping is also a better
 fit with the Scratch {index}`design principle` that
 everything in a project should be concrete and visible on the stage; in
-class/instance {span .mono}[OOP] the programming process begins with an abstract,
+class/instance {span .mono}`OOP` the programming process begins with an abstract,
 invisible entity, the class, that must be designed before any concrete
 objects can be made.[^7]
 
@@ -334,11 +334,11 @@ Programming Languages, Systems, and Applications \[OOPSLA-86\], ACM
 SigCHI, Portland, OR, September, 1986. Also in *Object-Oriented
 Computing,* Gerald Peterson, Ed., IEEE Computer Society Press, 1987.\]
 
-There are three ways to make a child sprite. If you {span .mono}[control-click] or
-{span .mono}[right-click] on a sprite in the “sprite corral” at the bottom right
+There are three ways to make a child sprite. If you {span .mono}`control-click` or
+{span .mono}`right-click` on a sprite in the “sprite corral” at the bottom right
 corner of the window, you get a menu that includes "`clone`" as one of the
 choices. There is an <code>a new clone of ( )</code> block
-in the {span .mono}[Control] palette that creates and reports a child sprite. And
+in the {span .mono}`Control` palette that creates and reports a child sprite. And
 sprites have a “parent” attribute that can be
 set, like any attribute, thereby *changing* the parent of an existing
 sprite.
@@ -369,7 +369,7 @@ changed in the parent, then the children see the new value. If the
 value of a shared property is changed in the *child*, then the sharing
 link is broken, and a new private version is created in that child.
 (This is the mechanism by which a child chooses not to share a property with its parent.) “Changed” in this context means using the
-<code>set ( ) to ( )</code> or <code>change ( ) by ( )</code> block for a variable, editing a block in the Block Editor, editing a costume or sound, or inserting, deleting, or reordering costumes or sounds. To change a property from unshared to shared, the child uses the <code>inherit</code> command block. The pulldown menu in the block lists all the things this sprite can inherit from its parent (which might be nothing, if this sprite has no parent) and is not already inheriting. But that would prevent <code>tell</code>ing a child to inherit, so if the <code>inherit</code> block is inside a <code>ring</code>, its pulldown menu includes all the things a child could inherit from this sprite. {span .mono}[Right-clicking] on the scripting area of a permanent clone gives a menu option to share the entire collection of scripts from its parent, as a temporary clone does.
+<code>set ( ) to ( )</code> or <code>change ( ) by ( )</code> block for a variable, editing a block in the Block Editor, editing a costume or sound, or inserting, deleting, or reordering costumes or sounds. To change a property from unshared to shared, the child uses the <code>inherit</code> command block. The pulldown menu in the block lists all the things this sprite can inherit from its parent (which might be nothing, if this sprite has no parent) and is not already inheriting. But that would prevent <code>tell</code>ing a child to inherit, so if the <code>inherit</code> block is inside a <code>ring</code>, its pulldown menu includes all the things a child could inherit from this sprite. {span .mono}`Right-clicking` on the scripting area of a permanent clone gives a menu option to share the entire collection of scripts from its parent, as a temporary clone does.
 
 The rules are full of details, but the basic idea is simple: Parents can
 change their children, but children can’t directly change their parents.

--- a/07-object-oriented-programming-with-sprites.md
+++ b/07-object-oriented-programming-with-sprites.md
@@ -95,7 +95,7 @@ block that accepts any input type, such as set’s (<code>set ( ) to ( )</code>)
 <code>say ( )</code> an object, the resulting speech balloon will contain a smaller image
 of the object’s costume or (for the stage) background.
 
-![image742.png](images/07-object-oriented-programming-with-sprites/image742.png) <!--  style="width:3.54514in;height:0.82639in" / -->
+{img alt="image742.png" width="2.62in"}`images/07-object-oriented-programming-with-sprites/image742.png`
 
 :::{index} temporary clone
 clone temporary
@@ -170,9 +170,9 @@ Editor.)
 The way to send a message to a sprite (or the stage) is with the <code>tell ( ) to ( )</code>
 block (for command messages) or the <code>say ( )</code> block (for reporter messages).
 
-![image749.png](images/07-object-oriented-programming-with-sprites/image749.png) <!--  style="width:3.54514in;height:0.82639in" / -->
+{img alt="image749.png" width="1.51in"}`images/07-object-oriented-programming-with-sprites/image749.png`
 
-![image750.png](images/07-object-oriented-programming-with-sprites/image750.png) <!--  style="width:3.54514in;height:0.82639in" / -->
+{img alt="image750.png" width="5.70in"}`images/07-object-oriented-programming-with-sprites/image750.png`
 
 A small point to note in the examples above: all dropdown menus include
 an empty entry at the top, which can be selected for use in higher order
@@ -181,7 +181,7 @@ procedures like the <code>for each</code> and <code>map</code> examples. Each of
 By the way, if you want a list of *all* the sprites, including this
 sprite, you can use either of these:
 
-![image751.png](images/07-object-oriented-programming-with-sprites/image751.png) <!--  style="width:3.54514in;height:0.82639in" / -->
+{img alt="image751.png" width="5.70in"}`images/07-object-oriented-programming-with-sprites/image751.png`
 
 <code>Tell ( )</code> and <code>ask ( ) and wait</code> wait until the
 other sprite has carried out its method before this sprite’s script
@@ -191,7 +191,7 @@ and wait</code>. Sometimes the other sprite’s method may take a long time, or
 may even be a forever loop, so you want the originating script to
 continue without waiting. For this purpose we have the <code>launch ( )</code> block:
 
-![image762.png](images/07-object-oriented-programming-with-sprites/image762.png) <!--  style="width:3.54514in;height:0.82639in" / -->
+{img alt="image762.png" width="3.55in"}`images/07-object-oriented-programming-with-sprites/image762.png`
 
 <code>Launch ( )</code> is analogous to <code>broadcast</code> without the “wait.”
 
@@ -214,7 +214,7 @@ Suppose you have a {span .mono}[Dog] sprite
 with two clones CockerSpaniel and PitBull. In the {span .mono}[Dog] sprite you define
 this method ("`For this sprite only`" block):
 
-![image763.png](images/07-object-oriented-programming-with-sprites/image763.png) <!--  style="width:1.67361in;height:1.40208in" / -->
+{img alt="image763.png" width="1.67in"}`images/07-object-oriented-programming-with-sprites/image763.png`
 
 Note the *loca*tion ({span .mono}[map-pin]) symbol before the
 block’s name. The symbol is not part of the block title; it’s a visual
@@ -223,11 +223,11 @@ similarly marked.
 
 But you don’t define <code>greet ( ) as friend</code> or <code>greet ( ) as enemy</code> in Dog. Each kind of dog has a different behavior. Here’s what a CockerSpaniel does:
 
-![image764.png](images/07-object-oriented-programming-with-sprites/image764.png) <!--  style="width:1.67361in;height:1.40208in" / -->
+{img alt="image764.png" width="4.07in"}`images/07-object-oriented-programming-with-sprites/image764.png`
 
 And here’s what a PitBull does:
 
-![image765.png](images/07-object-oriented-programming-with-sprites/image765.png) <!--  style="width:1.67361in;height:1.40208in" / -->
+{img alt="image765.png" width="4.05in"}`images/07-object-oriented-programming-with-sprites/image765.png`
 
 <code>Greet ( )</code> is defined in the {span .mono}[Dog] sprite.
 If Fido is a particular cocker
@@ -281,7 +281,7 @@ attributes: The {index}`my block`’s menu (in {span .mono}`Sensing`); see
 a sprite. It serves as a general getter for those attributes, e.g., <code>my
 (anchor)</code> to find the sprite, if any, to which this sprite is attached
 in a nesting arrangement (see
-@sec-nesting-sprites-anchors-and-parts). Similarly, the same <code>set ( ) to ( )</code> block
+@nesting-sprites-anchors-and-parts). Similarly, the same <code>set ( ) to ( )</code> block
 used to set variable values allows setting some sprite attributes.
 
 ![image766.png](images/07-object-oriented-programming-with-sprites/image766.png) <!--  style="width:1.67361in;height:1.40208in" / -->
@@ -381,7 +381,7 @@ in the parent (and therefore in itself and all its siblings)? Remember
 that in this system any object can <code>tell</code> any other object to do
 something:
 
-![image779.png](images/07-object-oriented-programming-with-sprites/image779.png) <!--  style="width:5.07292in;height:0.58333in" / -->
+{img alt="image779.png" width="5.07in"}`images/07-object-oriented-programming-with-sprites/image779.png`
 
 When a sprite gets a message
 for which it doesn’t have a corresponding block, the message is
@@ -391,7 +391,7 @@ that implements a delegated message refers to <code>my (self)</code>, it means t
 child to which the message was originally sent, not the parent to which
 the message was delegated.
 
-![image780.png](images/07-object-oriented-programming-with-sprites/image780.png) <!--  style="width:0.78958in;height:3.46806in" -->
+{img alt="image780.png" width="0.79in"}`images/07-object-oriented-programming-with-sprites/image780.png`
 
 :::{index} attributes, list of
 self (in my block)
@@ -420,7 +420,7 @@ center y (in my block)
 
 At the right is a picture of the dropdown menu of attributes in the <code>my ( )</code> block.
 
-![image770.png](images/07-object-oriented-programming-with-sprites/image770.png) <!--  style="width:5.07292in;height:0.58333in" / -->
+{img alt="image770.png" width="2.24in"}`images/07-object-oriented-programming-with-sprites/image770.png`
 
 Several of these are not real attributes, but things related to
 attributes:
@@ -551,7 +551,7 @@ reflects the way bitmaps are stored in the computer’s hardware and
 operating system, but also makes it easy to produce transformations of a
 costume with <code>map</code>:
 
-![image784.png](images/07-object-oriented-programming-with-sprites/image784.png) <!--  style="width:1.63194in;height:0.1875in" -->
+{img alt="image784.png" width="6.10in"}`images/07-object-oriented-programming-with-sprites/image784.png`
 
 In this simplest possible transformation, the red value of all the
 pixels have been changed to a constant 150. Colors that were red in the
@@ -576,22 +576,22 @@ there’s no <var>name</var> input; costumes computed in this way are all named
 <var>costume</var>. Note also that the use of switch to costume does *not* add the
 computed costume to the sprite’s wardrobe; to do that, say
 
-![image790.png](images/07-object-oriented-programming-with-sprites/image790.png) <!--  style="width:2.25694in;height:0.28472in" -->
+{img alt="image790.png" width="2.26in"}`images/07-object-oriented-programming-with-sprites/image790.png`
 
 Here’s a more interesting example of color manipulation:
 
-![image791.png](images/07-object-oriented-programming-with-sprites/image791.png) <!--  style="width:2.25694in;height:0.28472in" -->
+{img alt="image791.png" width="7.51in"}`images/07-object-oriented-programming-with-sprites/image791.png`
 
 Each
 color value is constrained to be 0, 80, 160, or 240. This gives the
 picture a more cartoonish look. Alternatively, you can do the
 computation taking advantage of hyperblocks:
 
-![image797.png](images/07-object-oriented-programming-with-sprites/image797.png) <!--  style="width:2.25694in;height:0.28472in" -->
+{img alt="image797.png" width="4.56in"}`images/07-object-oriented-programming-with-sprites/image797.png`
 
 Here’s one way to exchange red and green values:
 
-![image798.png](images/07-object-oriented-programming-with-sprites/image798.png) <!--  style="width:2.25694in;height:0.28472in" -->
+{img alt="image798.png" width="7.50in"}`images/07-object-oriented-programming-with-sprites/image798.png`
 
 It’s the {inline alt="image804.png"}`images/07-object-oriented-programming-with-sprites/image804.png` <!--  style="width:0.95833in;height:0.18056in" --> list that
 determines the rearrangement of colors: green➔red, red➔green, and the
@@ -608,7 +608,7 @@ expression such as {inline alt="image809.png"}`images/07-object-oriented-program
 original width and height, as advertised, so you can make fun house
 mirror versions of costumes:
 
-![image805.png](images/07-object-oriented-programming-with-sprites/image805.png) <!--  style="width:0.95833in;height:0.18056in" -->
+{img alt="image805.png" width="5.57in"}`images/07-object-oriented-programming-with-sprites/image805.png`
 
 The resulting costumes can be used with <code>switch to costume ( )</code> and so on.
 
@@ -633,15 +633,15 @@ trims it to fit on the selected sprite. (<code>Video snap on</code> stage means 
 use the entire stage-sized rectangle.) For example, here’s a camera
 snapshot trimmed to fit Alonzo:
 
-![image815.png](images/07-object-oriented-programming-with-sprites/image815.png) <!--  style="width:1.20417in;height:1.6125in" / -->
+{img alt="image815.png" width="1.20in"}`images/07-object-oriented-programming-with-sprites/image815.png`
 
 The “Video Capture” project in the Examples collection repeatedly takes such
 trimmed snapshots and has the Alonzo sprite use the current snapshot as
 its costume, so it looks like this:
 
-![image816.png](images/07-object-oriented-programming-with-sprites/image816.png) <!--  style="width:2.67014in;height:1.29861in" -->
+{img alt="image816.png" width="2.67in"}`images/07-object-oriented-programming-with-sprites/image816.png`
 
-![image818.png](images/07-object-oriented-programming-with-sprites/image818.png) <!--  style="width:3.33333in;height:2.5in" -->
+{img alt="image818.png" width="3.33in"}`images/07-object-oriented-programming-with-sprites/image818.png`
 
 (The picture above was
 actually taken with transparency set to 50, to make the background more
@@ -650,7 +650,7 @@ where the snapshot was taken, its costume exactly fits in with the rest
 of the full-stage video. If you were to add a <code>move (100) steps</code> block after
 the <code>switch to costume ( )</code>, you’d see something like this:
 
-![image817.png](images/07-object-oriented-programming-with-sprites/image817.png) <!--  style="width:2.66667in;height:2in" -->
+{img alt="image817.png" width="2.67in"}`images/07-object-oriented-programming-with-sprites/image817.png`
 
 This time, the sprite’s costume was captured at one position, and then
 the sprite is shown at a different position. (You probably wouldn’t want
@@ -658,7 +658,7 @@ to do this, but perhaps it’s helpful for explanatory purposes.)
 
 What you *would* want to do is push the sprite around the stage:
 
-![image819.png](images/07-object-oriented-programming-with-sprites/image819.png) <!--  style="width:2.66667in;height:2in" -->
+{img alt="image819.png" width="7.38in"}`images/07-object-oriented-programming-with-sprites/image819.png`
 
 <!-- Remove this? -->
 (Really these should be Jens’s picture; it’s his project. But he’s vacationing. ☺)
@@ -690,7 +690,7 @@ brief burst of sound from your microphone. (How
 brief? On my computer, 0.010667 seconds, but you’ll see shortly how to
 ﬁnd out or control the sample size on your computer.)
 
-![image825.png](images/07-object-oriented-programming-with-sprites/image825.png) <!--  style="width:3.09028in;height:1.92361in" -->
+{img alt="image825.png" width="3.09in"}`images/07-object-oriented-programming-with-sprites/image825.png`
 
 Just as the *pixel* is
 the smallest piece of a picture, the *sample* is the smallest piece of a
@@ -701,7 +701,7 @@ on the microphone—how hard the air is pushing—at that instant. (You can
 skip the next page or so if you know about Fourier analysis.) Here’s a
 picture of 400 samples:
 
-![image827.png](images/07-object-oriented-programming-with-sprites/image827.png) <!--  style="width:5.99931in;height:2.62014in" -->
+{img alt="image827.png" width="6.00in"}`images/07-object-oriented-programming-with-sprites/image827.png`
 
 In this graph, the *x* axis represents the time at which each sample was
 measured; the *y* axis measures the value of the sample at that time.
@@ -712,7 +712,7 @@ Every periodic function (more or less, any sample that sounds like music
 rather than sounding like static) is composed of a sum of sine wave
 s of different frequencies.
 
-![image829.png](images/07-object-oriented-programming-with-sprites/image829.png) <!--  style="width:2.78472in;height:1.04861in" -->
+{img alt="image829.png" width="2.78in"}`images/07-object-oriented-programming-with-sprites/image829.png`
 
 Look back at the graph of our sampled sound. There is a green dot every
 seven samples. There’s nothing magic about the number seven; I tried
@@ -747,7 +747,7 @@ shrill-sounding note. But remember that a complex waveform is the sum of
 multiple sine waves at different frequency. Here’s a different
 up-and-down regularity:
 
-![image828.png](images/07-object-oriented-programming-with-sprites/image828.png) <!--  style="width:2.79514in;height:1.22222in" -->
+{img alt="image828.png" width="2.80in"}`images/07-object-oriented-programming-with-sprites/image828.png`
 
 It’s not obvious, but in
 the left part of the graph, the signal is more above the *x* axis than
@@ -766,7 +766,7 @@ but is best known for working out the nature of periodic functions as a
 sum of sine waves.) Luckily we don’t have to do the math; the <code>microphone ( )</code>
 block will do it for us, if we ask for <code>microphone (spectrum)</code>:
 
-![image830.png](images/07-object-oriented-programming-with-sprites/image830.png) <!--  style="width:2.79514in;height:1.22222in" -->
+{img alt="image830.png" width="7.49in"}`images/07-object-oriented-programming-with-sprites/image830.png`
 
 These are frequency spectra from (samples of) three different songs. The
 most obvious thing about these graphs is that their overall slope is

--- a/08-oop-with-procedures.md
+++ b/08-oop-with-procedures.md
@@ -53,7 +53,7 @@ variable, so it remains active. (The <code>script variables</code> block makes v
 in a sprite’s script area or in the Block Editor. Script variables can
 be “exported” by being used in a reported procedure, as here.)
 
-In this approach to {span .mono}[OOP], we are representing both classes and instances
+In this approach to {span .mono}`OOP`, we are representing both classes and instances
 as procedures. The <code>make a counter</code> block represents the class, while each
 instance is represented by a nameless script created each time <code>make a
 counter</code> is called. The script variables created inside the <code>make a

--- a/08-oop-with-procedures.md
+++ b/08-oop-with-procedures.md
@@ -30,7 +30,7 @@ script variables block
 
 ## Local State with Script Variables
 
-![image852.png](images/08-oop-with-procedures/image852.png) <!--  style="width:2.23958in;height:1.51042in" / -->
+{img alt="image852.png" width="2.24in"}`images/08-oop-with-procedures/image852.png`
 
 This script implements an object *class*, a type of object, namely the counter class.
 In this ﬁrst simplified version there is only
@@ -72,7 +72,7 @@ In the simplified class above, there is only one method, and so there are no mes
 call the instance to carry out its one method. Here is a more refined
 version that uses {index}`message passing`:
 
-![image853.png](images/08-oop-with-procedures/image853.png) <!--  style="width:4.41667in;height:3.16667in" / -->
+{img alt="image853.png" width="4.42in"}`images/08-oop-with-procedures/image853.png`
 
 Again, the <code>make a counter</code> block represents the <var>counter</var> class, and again
 the script creates a local variable <var>count</var> each time it is invoked. The
@@ -100,7 +100,7 @@ that this is one of the rare cases in which we must unringify
 the inner <code>call</code> block, whose *value when called* gives
 the method.
 
-![image855.png](images/08-oop-with-procedures/image855.png) <!--  style="width:4.01042in;height:0.70772in" / -->
+{img alt="image855.png" width="3.91in"}`images/08-oop-with-procedures/image855.png`
 
 :::{index} inheritance
 delegation
@@ -115,7 +115,7 @@ of the {index}`child class` contains an instance of the
 {index}`parent class`, and simply passes on the messages it
 doesn’t want to specialize:
 
-![image857.png](images/08-oop-with-procedures/image857.png) <!--  style="width:3.8125in;height:3.58333in" / -->
+{img alt="image857.png" width="3.81in"}`images/08-oop-with-procedures/image857.png`
 
 This script implements the <var>buzzer</var> class, which is a child of <var>counter</var>.
 Instead of having a <var>count</var> (a number) as a local state variable, each
@@ -163,16 +163,16 @@ corresponding *value.* We provide a lookup procedure to locate the
 key-value pair corresponding to a given key in a
 given table.
 
-![image858.png](images/08-oop-with-procedures/image858.png) <!--  style="width:3.21528in;height:2.36111in" / -->
-![image859.png](images/08-oop-with-procedures/image859.png) <!--  style="width:2.625in;height:0.78125in" / -->
+{img alt="image858.png" width="3.22in"}`images/08-oop-with-procedures/image858.png`
+{img alt="image859.png" width="2.62in"}`images/08-oop-with-procedures/image859.png`
 
-![image860.png](images/08-oop-with-procedures/image860.png) <!--  style="width:5.60417in;height:1.15625in" / -->
-![image861.png](images/08-oop-with-procedures/image861.png) <!--  style="width:5.60417in;height:1.15625in" / -->
+{img alt="image860.png" width="5.60in"}`images/08-oop-with-procedures/image860.png`
+{img alt="image861.png" width="5.60in"}`images/08-oop-with-procedures/image861.png`
 
 There are also commands to <code>insert</code> and <code>delete</code> entries:
 
-![image863.png](images/08-oop-with-procedures/image863.png) <!--  style="width:3.22917in;height:2.12831in" / -->
-![image862.png](images/08-oop-with-procedures/image862.png) <!--  style="width:3.71875in;height:1.82639in" / -->
+{img alt="image863.png" width="3.23in"}`images/08-oop-with-procedures/image863.png`
+{img alt="image862.png" width="3.72in"}`images/08-oop-with-procedures/image862.png`
 
 As in the class/instance version, an object is represented as a dispatch
 procedure that takes a message as its input
@@ -203,20 +203,20 @@ and makes a child object. It should be considered as an internal part of
 the implementation; the preferred way to make a child of an object is to
 send that object a <var>clone</var> message.
 
-![image864.png](images/08-oop-with-procedures/image864.png) <!--  style="width:4.375in;height:7.46944in" / -->
+{img alt="image864.png" width="4.38in"}`images/08-oop-with-procedures/image864.png`
 
 Every    bject is created with predefined methods for <code>set, method, delete-var,
 delete-method, and clone</code>. It has one predefined variable, <var>parent</var>.
 Objects without a parent are created by calling <code>new object</code>:
 
-![image865.png](images/08-oop-with-procedures/image865.png) <!--  style="width:1.57292in;height:0.6875in" / -->
+{img alt="image865.png" width="1.57in"}`images/08-oop-with-procedures/image865.png`
 
 As before, we provide procedures to call an object’s dispatch procedure
 and then call the method. But in this version, we provide the desired
 object as the ﬁrst method input. We provide one procedure for Command
 methods and one for Reporter methods:
 
-![image866.png](images/08-oop-with-procedures/image866.png) <!--  style="width:1.57292in;height:0.6875in" / -->
+{img alt="image866.png" width="6.94in"}`images/08-oop-with-procedures/image866.png`
 
 (Remember that the <code>“Input list:”</code> variant of the <code>run</code> and <code>call</code> blocks is
 made by dragging the input expression over the arrowheads rather than
@@ -232,4 +232,4 @@ Running this script should <code>say</code> and <code>think</code> the following
 
 \[1 1\] \[2 2\] \[3 3\] \[4 4\] (1 5) (2 6) (3 7) \[5 8\] \[6 9\] \[7 10\] \[8 11\]
 
-![image870.png](images/08-oop-with-procedures/image870.png) <!--  style="width:4.20833in;height:4.39583in" / -->
+{img alt="image870.png" width="4.21in"}`images/08-oop-with-procedures/image870.png`

--- a/09-the-outside-world.md
+++ b/09-the-outside-world.md
@@ -46,7 +46,7 @@ Web page is typically a very long text string, and so the primitive
 manageable form, namely, as a list of lines:
 
 <!-- TODO: Shrink an image like this in the PDF so more stuff fits on the previous page... -->
-![image871.png](images/09-the-outside-world/image871.png)
+{img alt="image871.png" width="6.52in"}`images/09-the-outside-world/image871.png`
 
 The second input to split is the character to be used to separate the
 text string into a list of lines, or one of a set of common cases (such
@@ -124,10 +124,10 @@ out the current date or time. Each call to
 this block reports one component of the date or time,
 so you will probably combine several calls, like this:
 
-![image872.png](images/09-the-outside-world/image872.png) <!--  style="width:5.30556in;height:0.31944in" -->
+{img alt="image872.png" width="5.31in"}`images/09-the-outside-world/image872.png`
 
 for Americans, or like this:
 
-![image873.png](images/09-the-outside-world/image873.png) <!--  style="width:5.30556in;height:0.31944in" -->
+{img alt="image873.png" width="5.31in"}`images/09-the-outside-world/image873.png`
 
 for Europeans.

--- a/10-continuations.md
+++ b/10-continuations.md
@@ -22,29 +22,29 @@ multithreading.
 continuation of a command block may just be the part of the script after
 the block. For example, in the script
 
-![image874.png](images/10-continuations/image874.png) <!--  style="width:1.40625in;height:1.54167in" / -->
+{img alt="image874.png" width="1.41in"}`images/10-continuations/image874.png`
 
 the continuation of the move 100 steps block is
 
-![image875.png](images/10-continuations/image875.png) <!--  style="width:1.59375in;height:0.70833in" / -->
+{img alt="image875.png" width="1.59in"}`images/10-continuations/image875.png`
 
  But some situations are more
 complicated. For example, what is the continuation of move 100 steps in
 the following script?
 
-![image876.png](images/10-continuations/image876.png) <!--  style="width:1.47847in;height:0.80208in" / -->
+{img alt="image876.png" width="1.48in"}`images/10-continuations/image876.png`
 
  That’s a trick question; the
 move block is run four times, and it has a different continuation each
 time. The first time, its continuation is
 
-![image877.png](images/10-continuations/image877.png) <!--  style="width:1.66667in;height:1.07292in" / -->
+{img alt="image877.png" width="1.67in"}`images/10-continuations/image877.png`
 
 Note that there is no repeat 3 block in the actual script, but the
 continuation has to represent the fact that there are three more times
 through the loop to go. The fourth time, the continuation is just
 
-![image878.png](images/10-continuations/image878.png) <!--  style="width:1.59375in;height:0.29792in" / -->
+{img alt="image878.png" width="1.59in"}`images/10-continuations/image878.png`
 
 What counts is not what’s
 physically below the block in the script, but what computational work
@@ -60,15 +60,15 @@ represent what work the process still has left to do.)
 When a block is used inside a custom block, its continuation may include
 parts of more than one script. For example, if we make a custom square
 block
-![image879.png](images/10-continuations/image879.png) <!--  style="width:1.47917in;height:1.25in" / -->
+{img alt="image879.png" width="1.48in"}`images/10-continuations/image879.png`
 
 and then use that block in a script:
 
-![image880.png](images/10-continuations/image880.png) <!--  style="width:0.72917in;height:0.59375in" / -->
+{img alt="image880.png" width="0.73in"}`images/10-continuations/image880.png`
 
 then the continuation of the first use of move 100 steps is
 
-![image881.png](images/10-continuations/image881.png) <!--  style="width:1.66667in;height:1.26042in" / -->
+{img alt="image881.png" width="1.67in"}`images/10-continuations/image881.png`
 
 in which part comes from inside the square block and part comes from the call to square.
 Nevertheless, ordinarily when we *display* a continuation we show only
@@ -79,11 +79,11 @@ no input slots. But the continuation of a *reporter* block has to do
 something with the value reported by the block, so it takes that value
 as input. For example, in the script
 
-![image882.png](images/10-continuations/image882.png) <!--  style="width:2.1875in;height:0.57292in" / -->
+{img alt="image882.png" width="2.19in"}`images/10-continuations/image882.png`
 
 the continuation of the 3+4 block is
 
-![image883.png](images/10-continuations/image883.png) <!--  style="width:3.57292in;height:0.57292in" / -->
+{img alt="image883.png" width="3.57in"}`images/10-continuations/image883.png`
 
 Of course the name result in
 that picture is arbitrary; any name could be used, or no name at all by
@@ -113,12 +113,12 @@ they’re actually performed.
 That may seem like overkill in a simple expression, but suppose you’re trying
 to convey the expression
 
-![image885.png](images/10-continuations/image885.png) <!--  style="width:3.1875in;height:0.35417in" / -->
+{img alt="image885.png" width="3.19in"}`images/10-continuations/image885.png`
 
 to a friend over the phone. If you say “factorial of three times
 factorial of two plus two plus five” you might mean any of these:
 
-![image886.png](images/10-continuations/image886.png) <!--  style="width:3.1875in;height:0.35417in" / -->
+{img alt="image886.png" width="3.19in"}`images/10-continuations/image886.png`
 
 Wouldn’t it be better to say, “Add two and two, take the factorial of
 that, add five to that, multiply three by that, and take the factorial
@@ -127,16 +127,16 @@ first define versions of all the reporters that take their continuation
 as an explicit input. In the following picture, notice that the new
 blocks are *commands*, not reporters.
 
-![image887.png](images/10-continuations/image887.png) <!--  style="width:3.1875in;height:0.35417in" / -->
+{img alt="image887.png" width="3.19in"}`images/10-continuations/image887.png`
 
 We can check that these blocks give the results we want:
 
-![image888.png](images/10-continuations/image888.png) <!--  style="width:3.1875in;height:0.35417in" / -->
+{img alt="image888.png" width="3.19in"}`images/10-continuations/image888.png`
 
 
 The original expression can now be represented as
 
-![image908.png](images/10-continuations/image908.png) <!--  style="width:5.53333in;height:2.31806in" / -->
+{img alt="image908.png" width="5.53in"}`images/10-continuations/image908.png`
 
 If you read this top to
 bottom, don’t you get “Add two and two, take the factorial of that, add
@@ -160,7 +160,7 @@ who computes 29. And so on, until finally Sam, a say specialist, says
 the value 2.107757298379527×10<sup>132</sup>, which is a very large
 number!
 
-![image909.png](images/10-continuations/image909.png) <!--  style="width:2.19306in;height:1.05278in" / -->
+{img alt="image909.png" width="2.19in"}`images/10-continuations/image909.png`
 
 Go back to the definitions of these blocks. The ones, such as add, that
 correspond to primitive reporters are simple; they just call the
@@ -197,20 +197,20 @@ Here’s the classic example. We want to write a recursive block that
 takes a list of numbers as input, and reports the product of all the
 numbers:
 
-![image911.png](images/10-continuations/image911.png) <!--  style="width:3.89583in;height:1.34167in" / -->
+{img alt="image911.png" width="3.90in"}`images/10-continuations/image911.png`
 
 But we can improve the
 efficiency of this block, in the case of a list that includes a zero; as
 soon as we see the zero, we know that the entire product is zero.
 
-![image910.png](images/10-continuations/image910.png) <!--  style="width:3.89583in;height:1.9375in" / -->
+{img alt="image910.png" width="3.90in"}`images/10-continuations/image910.png`
 
 But this is not as efficient as it might seem. Consider, as an example,
 the list 1,2,3,0,4,5. We find the zero on the third recursive call (the
 fourth call altogether), as the first item of the sublist 0,4,5. What is
 the continuation of the report 0 block? It’s
 
-![image912.png](images/10-continuations/image912.png) <!--  style="width:4.33333in;height:0.41667in" / -->
+{img alt="image912.png" width="4.33in"}`images/10-continuations/image912.png`
 
 Even though we already know
 that result is zero, we’re going to do three unnecessary multiplications
@@ -225,7 +225,7 @@ one-input script, as shown in the product example. It calls that script
 with *the continuation of the* call-with-continuation *block itself* as
 its input. In this case, that continuation is
 
-![image915.png](images/10-continuations/image915.png) <!--  style="width:2.70833in;height:0.29167in" / -->
+{img alt="image915.png" width="2.71in"}`images/10-continuations/image915.png`
 
 reporting to whichever script called product. If the input list doesn’t include a zero, then nothing
 is ever done with that continuation, and this version works just like
@@ -235,11 +235,11 @@ continuation,* with an input of 0. The continuation immediately reports
 that 0 to the caller of product, *without* unwinding all the recursive
 calls and without the unnecessary multiplications.
 
-![image917.png](images/10-continuations/image917.png) <!--  style="width:4.40625in;height:1.15625in" / -->
+{img alt="image917.png" width="4.41in"}`images/10-continuations/image917.png`
 
 I could have written product a little more simply using a Reporter ring instead of a Command ring:
 
-![image918.png](images/10-continuations/image918.png) <!--  style="width:4.38542in;height:0.51042in" / -->
+{img alt="image918.png" width="4.39in"}`images/10-continuations/image918.png`
 
 but it’s customary to use a script to represent the input to
 call** **w/continuation because very often that input takes the form
@@ -269,14 +269,14 @@ we can generalize this mechanism to allow nonlocal exit even within a
 block called from inside a loop, or through several levels of nested
 loops:
 
-![image920.png](images/10-continuations/image920.png) <!--  style="width:1.85417in;height:2.65347in" / -->
+{img alt="image920.png" width="6.27in"}`images/10-continuations/image920.png`
 
 The upvar break has as its value a continuation that can be called from
 anywhere in the program to jump immediately to whatever comes after the
 catch block in its script. Here’s an example with two nested invocations
 of catch, with the upvar renamed in the outer one:
 
-![image923.png](images/10-continuations/image923.png) <!--  style="width:1.85417in;height:2.65347in" / -->
+{img alt="image923.png" width="1.85in"}`images/10-continuations/image923.png`
 
 As shown, this will say 1, then 2, then 3, then exit both nested catches
 and think “Hmm.” If in the run block the variable break is used instead
@@ -290,7 +290,7 @@ value to its own continuation, but instead reports a value (which it
 takes as an additional input, in addition to the catch tag) to *the
 corresponding catch block*’s continuation:
 
-![image924.png](images/10-continuations/image924.png) <!--  style="width:1.85417in;height:2.65347in" / -->
+{img alt="image924.png" width="4.35in"}`images/10-continuations/image924.png`
 
 Without the throw, the inner call reports 5, the + block reports 8, so
 the catch block reports 8, and the × block reports 80. With the throw,
@@ -324,7 +324,7 @@ it to the task list, and then runs the first waiting task. The
 end** **thread block (which is automatically added at the end of every
 thread’s script by the thread block) just runs the next waiting task.
 
-![image925.png](images/10-continuations/image925.png) <!--  style="width:1.85417in;height:2.65347in" / -->
+{img alt="image925.png" width="4.35in"}`images/10-continuations/image925.png`
 
 Here is a sample script using the thread system. One thread says
 numbers; the other says letters. The number thread yields after every
@@ -334,7 +334,7 @@ sequence of speech balloons is
 1,2,a,3,b,c,d,e,4,5,f,g,h,i,6,7,j,k,l,m,n,o,8,9,10,11,
 p,q,r,s,t,u,12,13,v,w,x,y,z,14,15,16,17,18,…30.
 
-![image928.png](images/10-continuations/image928.png) <!--  style="width:2.94792in;height:4.25417in" / -->
+{img alt="image928.png" width="2.95in"}`images/10-continuations/image928.png`
 
 If we wanted this to behave exactly like Snap<em>!</em>’s own threads, we’d
 define new versions of repeat and so on that run yield after each

--- a/11-metaprogramming.md
+++ b/11-metaprogramming.md
@@ -31,7 +31,7 @@ expression or script as input (ringed) and reports a list representing a
 block with no inputs and the remaining items are the input values, which
 may themselves be syntax trees.
 
-![image377.png](images/11-metaprogramming/image377.png) <!--  style="width:1.15in;height:0.19in" alt="A picture containing text, hitting Description automatically generated" / -->
+{img alt="image377.png" width="0.88in"}`images/11-metaprogramming/image377.png`
 
 Using split by blocks to select custom blocks whose definitions contain
 another block gives us this debugging aid:
@@ -87,7 +87,7 @@ Note in the case of the for block’s label that the upvar (the i) and the
 C-slot both count as inputs. Note also that the label is not meant to be
 a unique symbol that represents only this block. For example,
 ![image628.png](images/11-metaprogramming/image628.png) <!--  style="width:0.86111in;height:0.19444in" / -->  and
-![image376.png](images/11-metaprogramming/image376.png) <!--  style="width:1.15in;height:0.19in" alt="A picture containing text, hitting Description automatically generated" / -->
+{img alt="image376.png" width="1.22in"}`images/11-metaprogramming/image376.png`
 both have the label
 
 \_ of \_. The label does not give the input slots names (that’s done in
@@ -106,7 +106,7 @@ upvar is to allow that. In the example on the previous page, there are
 four set
 \_ of block \_ to \_ blocks, reproduced below for your convenience:
 
-![image951.png](images/11-metaprogramming/image951.png) <!--  style="width:2.83in;height:0.97in" alt="Graphical user interface, website Description automatically generated" / -->
+{img alt="image951.png" width="2.83in"}`images/11-metaprogramming/image951.png`
 
 The category of the block can be set to any primitive or custom
 category. The default is other. The type is command, reporter, or
@@ -123,12 +123,12 @@ It's very important that these set blocks appear in the same script as the
 define that creates the block, because the block upvar is local to that
 script. You can’t later say, for example,
 
-![image952.png](images/11-metaprogramming/image952.png) <!--  style="width:4.31in;height:0.83in" -->
+{img alt="image952.png" width="4.31in"}`images/11-metaprogramming/image952.png`
 
 because the copy of the hexagon block in this instruction counts as
 “using” it.
 
-![image953.png](images/11-metaprogramming/image953.png) <!--  style="width:2.6in;height:0.32in" / -->
+{img alt="image953.png" width="2.60in"}`images/11-metaprogramming/image953.png`
 
 The of block reporter is useful to copy attributes from one block to another,
 as we copied the definition of square, modified it, and used it to
@@ -151,32 +151,32 @@ There are a few more attributes of a block, less commonly used.
 The list input is just like the one for set slots except for default values
 instead of types. Now for a block with a menu input:
 
-![image961.png](images/11-metaprogramming/image961.png) <!--  style="width:3.29097in;height:0.60972in" / -->
+{img alt="image961.png" width="3.29in"}`images/11-metaprogramming/image961.png`
 
-![image962.png](images/11-metaprogramming/image962.png) <!--  style="width:2.35in;height:2.56in" alt="Graphical user interface, application Description automatically generated" / -->
+{img alt="image962.png" width="2.35in"}`images/11-metaprogramming/image962.png`
 
-![image965.png](images/11-metaprogramming/image965.png) <!--  style="width:1.66944in;height:0.25in" alt="Graphical user interface, text, application Description automatically generated" / -->
+{img alt="image965.png" width="4.69in"}`images/11-metaprogramming/image965.png`
 
 Prefer a read-only menu?
 
-![image956.png](images/11-metaprogramming/image956.png) <!--  style="width:3.51944in;height:0.61944in" alt="Graphical user interface, text, website Description automatically generated" / -->
+{img alt="image956.png" width="3.52in"}`images/11-metaprogramming/image956.png`
 
-![image963.png](images/11-metaprogramming/image963.png) <!--  style="width:1.66944in;height:0.25in" alt="Graphical user interface, text, application Description automatically generated" / -->
+{img alt="image963.png" width="1.67in"}`images/11-metaprogramming/image963.png`
 
 We passed too quickly over how the script turned the square block into a
 hexagon block:
 
-![image964.png](images/11-metaprogramming/image964.png) <!--  style="width:4.16944in;height:1.26944in" alt="Graphical user interface, website Description automatically generated" / -->
+{img alt="image964.png" width="4.17in"}`images/11-metaprogramming/image964.png`
 
 Those replace item blocks aren’t very elegant. I had to look at foo by
 hand to figure out where the numbers I wanted to change are. This
 situation can be improved with a little programming:
 
-![image966.png](images/11-metaprogramming/image966.png) <!--  style="width:4.16944in;height:1.26944in" alt="Graphical user interface, website Description automatically generated" / -->
+{img alt="image966.png" width="1.45in"}`images/11-metaprogramming/image966.png`
 
 Exercise for the reader: Implement this:
 
-![image971.png](images/11-metaprogramming/image971.png) <!--  style="width:3.11in;height:0.57in" alt="Graphical user interface Description automatically generated" / -->
+{img alt="image971.png" width="3.11in"}`images/11-metaprogramming/image971.png`
 
 Returning to the define block, there’s another reason for the block
 upvar: It’s helpful in defining a recursive procedure using define
@@ -185,14 +185,14 @@ itself, it needs a name for itself. But in the definition input to the
 define block, define itself hasn’t been called yet, so the new block
 isn’t in the palette yet. So you do this:
 
-![image972.png](images/11-metaprogramming/image972.png) <!--  style="width:3.11in;height:0.57in" alt="Graphical user interface Description automatically generated" / -->
+{img alt="image972.png" width="3.57in"}`images/11-metaprogramming/image972.png`
 
 Yes, you put block in the define, but it gets changed into this script
 in the resulting definition.
 
-![image973.png](images/11-metaprogramming/image973.png) <!--  style="width:3.11in;height:0.57in" alt="Graphical user interface Description automatically generated" / -->
+{img alt="image973.png" width="3.60in"}`images/11-metaprogramming/image973.png`
 
-![image974.png](images/11-metaprogramming/image974.png) <!--  style="width:3.11in;height:0.57in" alt="Graphical user interface Description automatically generated" / -->
+{img alt="image974.png" width="1.77in"}`images/11-metaprogramming/image974.png`
 
 ![image975.png](images/11-metaprogramming/image975.png) <!--  style="width:3.11in;height:0.57in" alt="Graphical user interface Description automatically generated" / -->
 
@@ -253,7 +253,7 @@ the real game.) It doesn’t just report out of the entire toplevel
 script; you can see that map is able to prepend “The answer is” to each
 reported value.
 
-![image992.png](images/11-metaprogramming/image992.png) <!--  style="width:3.03958in;height:0.23958in" / -->
+{img alt="image992.png" width="3.04in"}`images/11-metaprogramming/image992.png`
 
 This macro capability isn’t fully implemented. First, we shouldn’t have
 to use the calling script as an explicit input to the macro. In a later

--- a/12-user-interface-elements.md
+++ b/12-user-interface-elements.md
@@ -45,7 +45,7 @@ source files for Snap!
 The Snap<em>!</em> logo at the left end of the tool bar
 is clickable. It shows a menu of options about Snap<em>!</em> itself:
 
-![Snap! logo menu showing options: About, Reference Manual, Snap! Website and Download Source](images/12-user-interface-elements/image994.png) <!--  style="width:2.32922in;height:1.02in" / -->
+{img alt="Snap! logo menu showing options: About, Reference Manual, Snap! Website and Download Source" width="2.33in"}`images/12-user-interface-elements/image994.png`
 
 The "`About`" option displays information about Snap<em>!</em>
 itself, including version numbers for the source modules, the
@@ -129,7 +129,7 @@ in other software.
 The "`Open…`" option shows a project open dialog box in
 which you can choose a project to open:
 
-![The Open Project Dialog in Snap!](images/12-user-interface-elements/image995.png) <!--  style="width:2.88958in;height:2.09792in" / -->
+{img alt="The Open Project Dialog in Snap!" width="2.89in"}`images/12-user-interface-elements/image995.png`
 
 In this dialog, the three large buttons at the left select a source of
 projects: "`Cloud`" means your Snap<em>!</em> account’s cloud
@@ -144,12 +144,12 @@ stage when it was saved) and its project notes at the right.
 The {index}`search bar` at the top can be used to find a project by name or text in the
 project notes. So in this example:
 
-![The open dialog showing a search filter for the text "cre"](images/12-user-interface-elements/image996.png) <!--  style="width:2.72431in;height:1.97778in" / -->
+{img alt="The open dialog showing a search filter for the text \"cre\"" width="2.72in"}`images/12-user-interface-elements/image996.png`
 
 I was looking for my {index}`ice cream` projects and typed “crea” in
 the search bar, then wondered why “ferris” matched. But then when I clicked on ferris I saw this:
 
-![Open dialog showing a project called "ferris" selected](images/12-user-interface-elements/image997.png) <!--  style="width:2.72361in;height:1.97778in" / -->
+{img alt="Open dialog showing a project called \"ferris\" selected" width="2.72in"}`images/12-user-interface-elements/image997.png`
 
 My search matched the word “re*crea*te” in the project notes.
 
@@ -196,7 +196,7 @@ be logged in to save to the cloud.)
 The "`Save as…`" menu option opens a dialog box in
 which you can specify where to save the project:
 
-![The "Save as…" dialog in Snap!](images/12-user-interface-elements/image998.png) <!--  style="width:3.23611in;height:2.34931in" / -->
+{img alt="The \"Save as…\" dialog in Snap!" width="3.24in"}`images/12-user-interface-elements/image998.png`
 
 This is much like the "`Open`" dialog, except for the horizontal text box at
 the top, into which you type a name for the project. You can also
@@ -289,7 +289,7 @@ scene* rather than replacing the current project.)
 The "`Libraries…`" option presents a menu of
 useful, optional block libraries:
 
-![The libraries import dialog](images/12-user-interface-elements/image992.png) <!--  style="width:1.16667in;height:0.19792in" / -->
+{img alt="The libraries import dialog" width="3.04in"}`images/12-user-interface-elements/image992.png`
 
 **The following sections of the libraries dialog are out of date. (8/1/2025)**
 
@@ -322,7 +322,7 @@ needs. The libraries are described in detail in Section I.H, @sec-libraries.
 
 The "`Costumes…`" option opens a browser into the costume library:
 
-![image1000.png](images/12-user-interface-elements/image1000.png) <!--  style="width:4.28125in;height:3.23958in" / -->
+{img alt="image1000.png" width="4.28in"}`images/12-user-interface-elements/image1000.png`
 
 You can import a single costume by clicking it and then clicking the
 Import button. Alternatively, you can import more than one costume by
@@ -334,7 +334,7 @@ If you have the stage selected in the sprite corral, rather than a
 sprite, the Costumes… option changes to a Backgrounds… option
 , with different choices in the browser:
 
-![image1001.png](images/12-user-interface-elements/image1001.png) <!--  style="width:4.28125in;height:3.23958in" / -->
+{img alt="image1001.png" width="4.28in"}`images/12-user-interface-elements/image1001.png`
 
 The costume and background
 libraries include both bitmap (go jagged if enlarged) and
@@ -345,7 +345,7 @@ vector image, but instead convert it to bitmap.
 The Sounds… option opens the third kind of media
 browser:
 
-![image1002.png](images/12-user-interface-elements/image1002.png) <!--  style="width:4.28125in;height:3.23958in" / -->
+{img alt="image1002.png" width="4.28in"}`images/12-user-interface-elements/image1002.png`
 
 The Play buttons can be used to preview the sounds.
 
@@ -368,7 +368,7 @@ Change password… option
 The cloud icon {inline alt="image1008.png"}`images/12-user-interface-elements/image1008.png` <!--  style="width:0.29167in;height:0.16667in" / --> ![image1004.png](images/12-user-interface-elements/image1004.png) <!--  style="width:0.29167in;height:0.16667in" / --> shows a menu of options relating to your Snap<em>!</em> cloud account. If
 you are not logged in, you see the outline icon  ![image1004.png](images/12-user-interface-elements/image1004.png) <!--  style="width:0.29167in;height:0.16667in" / --> and get this menu:
 
-![image1003.png](images/12-user-interface-elements/image1003.png) <!--  style="width:1.43681in;height:0.75972in" / -->
+{img alt="image1003.png" width="1.44in"}`images/12-user-interface-elements/image1003.png`
 
 Choose Login… if you have a Snap<em>!</em> account and
 remember your password. Choose Signup… if you
@@ -385,7 +385,7 @@ outside the school.) The Open in Community Site option appears only if you have 
 If you are already logged in,
 you’ll see the solid icon {inline alt="image1008.png"}`images/12-user-interface-elements/image1008.png` <!--  style="width:0.29167in;height:0.16667in" / -->  and get this menu:
 
-![image1007.png](images/12-user-interface-elements/image1007.png) <!--  style="width:1.61111in;height:0.65278in" / -->
+{img alt="image1007.png" width="1.61in"}`images/12-user-interface-elements/image1007.png`
 
 Logout is obvious, but has the additional benefit
 of showing you who’s logged in. Change password… will ask for your old password (the temporary one if you’re
@@ -431,7 +431,7 @@ The settings icon {inline alt="image1010.png"}`images/12-user-interface-elements
 shows a menu of Snap<em>!</em> options, either for the
 current project or for you permanently, depending on the option:
 
-![image1009.png](images/12-user-interface-elements/image1009.png) <!--  style="width:1.24792in;height:2.58333in" / -->
+{img alt="image1009.png" width="1.25in"}`images/12-user-interface-elements/image1009.png`
 
 The Language… option lets you see the Snap<em>!</em>
 user interface (blocks and messages) in a language other than English.
@@ -450,7 +450,7 @@ practical. Note that a zoom of 2 is gigantic! Don’t even try 10.
 The Fade blocks… option opens a dialog in
 which you can change the appearance of blocks:
 
-![image1011.png](images/12-user-interface-elements/image1011.png) <!--  style="width:0.29167in;height:0.16667in" / -->
+{img alt="image1011.png" width="7.48in"}`images/12-user-interface-elements/image1011.png`
 
 Mostly this is a propaganda aid to use on people who think that text
 languages are somehow better or more grown up than block languages, but
@@ -482,8 +482,8 @@ uses it.
 
 The Extension blocks option adds two blocks to the palette:
 
-![image1021.png](images/12-user-interface-elements/image1021.png) <!--  style="width:1.18958in;height:0.18958in" alt="Graphical user interface, application Description automatically generated" / -->
-![image1022.png](images/12-user-interface-elements/image1022.png) <!--  style="width:1.22986in;height:0.25972in" alt="Graphical user interface, text, application Description automatically generated" / -->
+{img alt="image1021.png" width="1.19in"}`images/12-user-interface-elements/image1021.png`
+{img alt="image1022.png" width="1.23in"}`images/12-user-interface-elements/image1022.png`
 
 These blocks provide assorted capabilities to official libraries that
 were formerly implemented with the JavaScript function block. This
@@ -494,7 +494,7 @@ Input sliders provides an alternate way to put values in numeric input
 slots; if you click in such a slot, a slider appears that you can
 control with the mouse:
 
-![image1024.png](images/12-user-interface-elements/image1024.png) <!--  style="width:1.63889in;height:0.41319in" / -->
+{img alt="image1024.png" width="1.64in"}`images/12-user-interface-elements/image1024.png`
 
 The range of the slider will be from 25 less than the input’s current
 value to 25 more than the current value. If you want to make a bigger
@@ -515,7 +515,7 @@ Examples collection shows how this can be used; it features a fractal
 tree custom block with several inputs, and you can see how each input
 affects the picture by moving a slider.
 
-![image1023.png](images/12-user-interface-elements/image1023.png) <!--  style="width:1.10486in;height:2.08333in" / -->
+{img alt="image1023.png" width="1.10in"}`images/12-user-interface-elements/image1023.png`
 
 Turbo mode makes many projects run much
 faster, at the cost of not keeping the stage display up to date.
@@ -616,7 +616,7 @@ language. The feature doesn’t know about any particular other language;
 instead, you can provide a translation for each primitive block using
 these special blocks:
 
-![image1025.png](images/12-user-interface-elements/image1025.png) <!--  style="width:1.10486in;height:2.08333in" / -->
+{img alt="image1025.png" width="3.12in"}`images/12-user-interface-elements/image1025.png`
 
 Using these primitive blocks, you can build a block library to translate
 into any programming language. Watch for such libraries to be added to
@@ -780,22 +780,22 @@ Most elements of the Snap<em>!</em> display can be
 control-clicked/right-clicked to show a *context menu* *,* with items relevant to that element. If youcontrol-click/right-click a *primitive* block in the palette, you see
 this menu:
 
-![image1051.png](images/12-user-interface-elements/image1051.png) <!--  style="width:0.86111in;height:0.45903in" / -->
+{img alt="image1051.png" width="0.86in"}`images/12-user-interface-elements/image1051.png`
 
 The help… option displays a box with documentation about the block. Here’s an example:
 
-![image1053.png](images/12-user-interface-elements/image1053.png) <!--  style="width:3.32222in;height:2.42778in" / -->
+{img alt="image1053.png" width="3.32in"}`images/12-user-interface-elements/image1053.png`
 
 If you control-click/right-click a *custom* (user-defined) block in the
 palette, you see this menu:
 
-![image1052.png](images/12-user-interface-elements/image1052.png) <!--  style="width:1.62292in;height:0.88889in" / -->
+{img alt="image1052.png" width="1.62in"}`images/12-user-interface-elements/image1052.png`
 
 The help… option for a custom block displays the comment, if any, attached to the custom block’s hat
 block in the Block Editor. Here is an example of a block with a comment
 and its help display:
 
-![image1054.png](images/12-user-interface-elements/image1054.png) <!--  style="width:1.62292in;height:0.88889in" / -->
+{img alt="image1054.png" width="6.76in"}`images/12-user-interface-elements/image1054.png`
 
 If the help text includes a URL, it is clickable and will open the page
 in a new tab.
@@ -833,7 +833,7 @@ SciSnap!
 Right-click/control-click on the grey
 *background* of the palette area shows this menu:
 
-![image1058.png](images/12-user-interface-elements/image1058.png) <!--  style="width:0.98958in;height:0.58958in" / -->
+{img alt="image1058.png" width="0.99in"}`images/12-user-interface-elements/image1058.png`
 
 The `find blocks…` option does the same thing as
 the magnifying-glass button. The hide blocks… option opens a dialog box in which you can choose which blocks (custom
@@ -841,20 +841,20 @@ as well as primitive) should be hidden. (Within that dialog box, the
 context menu of the background allows you to check or uncheck all the
 boxes at once.)
 
-![image1059.png](images/12-user-interface-elements/image1059.png) <!--  style="width:1.6in;height:2.15972in" -->
+{img alt="image1059.png" width="1.60in"}`images/12-user-interface-elements/image1059.png`
 
 The make a category… option, which is
 intended mainly for authors of snap extensions, lets you add custom
 *categories* to the palette. It opens a small dialog window in which you
 specify a name *and a color* for the new category:
 
-![image1061.png](images/12-user-interface-elements/image1061.png) <!--  style="width:1.53in;height:1.13in" alt="Graphical user interface, text Description automatically generated" / -->
+{img alt="image1061.png" width="1.53in"}`images/12-user-interface-elements/image1061.png`
 
 Pick a dark color, because it will be lightened for zebra coloring when users
 nest blocks of the same category. Custom categories are shown below the
 built-in categories in the category selector:
 
-![image1060.png](images/12-user-interface-elements/image1060.png) <!--  style="width:1.42986in;height:2.90972in" alt="Graphical user interface, application Description automatically generated" / -->
+{img alt="image1060.png" width="1.43in"}`images/12-user-interface-elements/image1060.png`
 
 This example comes {index}`from Eckart<single: Eckart, from>` Modrow’s SciSnap<em>!</em>
 library. Note that the custom category list has its own
@@ -868,7 +868,7 @@ number, so that he could control their order.
 If there are no blocks visible in a category, the category name is
 dimmed in the category selector:
 
-![image1062.png](images/12-user-interface-elements/image1062.png) <!--  style="width:1.35in;height:1.83958in" -->
+{img alt="image1062.png" width="1.35in"}`images/12-user-interface-elements/image1062.png`
 
 Here we see that category foo has blocks in it, but categories bar and
 garply are empty. The built-in categories are also subject to dimming,
@@ -882,7 +882,7 @@ rightward to increase the width of the palette area. This is useful if
 you write custom blocks with very long names. You can’t reduce the width
 of the palette below its standard value.
 
-![image1063.png](images/12-user-interface-elements/image1063.png) <!--  style="width:1.41667in;height:1.51389in" / -->
+{img alt="image1063.png" width="1.42in"}`images/12-user-interface-elements/image1063.png`
 
 :::{index} current sprite
 thumbnail
@@ -909,7 +909,7 @@ appearance is different, with some primitives not shown.
 
 At the top of the scripting area are a picture of the sprite and some controls for it:
 
-![image1064.png](images/12-user-interface-elements/image1064.png) <!--  style="width:3.48611in;height:1.04167in" / -->
+{img alt="image1064.png" width="3.49in"}`images/12-user-interface-elements/image1064.png`
 
 Note that the sprite picture reflects its rotation, if any. There are
 three things that can be controlled here:
@@ -940,7 +940,7 @@ Just
 below the sprite controls are three *tabs* that determine what is shown
 in the scripting area:
 
-![image1065.png](images/12-user-interface-elements/image1065.png) <!--  style="width:3.09722in;height:0.25in" / -->
+{img alt="image1065.png" width="3.10in"}`images/12-user-interface-elements/image1065.png`
 
 :::{index} clicking on a script
 green halo
@@ -1016,11 +1016,11 @@ Control-click/right-clicking a primitive block within a script
 shows a menu like this one:
 
 command block:
-![image1070.png](images/12-user-interface-elements/image1070.png) <!--  style="width:0.62639in;height:1.09028in" / -->
+{img alt="image1070.png" width="0.63in"}`images/12-user-interface-elements/image1070.png`
 
 
 reporter block:
-![image1069.png](images/12-user-interface-elements/image1069.png) <!--  style="width:0.62083in;height:1.0625in" / -->
+{img alt="image1069.png" width="0.62in"}`images/12-user-interface-elements/image1069.png`
 
 The help… option shows the help screen for the
 block, just as in the palette. The other options appear only when a
@@ -1032,7 +1032,7 @@ When present, it allows the block to be replaced by another, similar
 block, keeping the input expressions in place. For example, here’s what
 happens when you choose relabel… for an arithmetic operator:
 
-![image1071.png](images/12-user-interface-elements/image1071.png) <!--  style="width:1.53in;height:2.13in" / -->
+{img alt="image1071.png" width="1.53in"}`images/12-user-interface-elements/image1071.png`
 
 Note that the inputs to the existing – block are displayed in the menu
 of alternatives also. Click a block in the menu to choose it, or click
@@ -1114,7 +1114,7 @@ Clicking a *custom* block in
 a script gives a similar but different
 menu:
 
-![image1073.png](images/12-user-interface-elements/image1073.png) <!--  style="width:0.97361in;height:1.29861in" / -->
+{img alt="image1073.png" width="0.97in"}`images/12-user-interface-elements/image1073.png`
 
 The relabel… option for custom blocks shows a
 menu of other same-shape custom blocks with the same inputs. At present
@@ -1126,7 +1126,7 @@ If a reporter block is in the
 scripting area, possibly with inputs included, but not itself serving as
 input to another block, then the menu is a little different again:
 
-![image1074.png](images/12-user-interface-elements/image1074.png) <!--  style="width:0.88125in;height:1.08333in" / -->
+{img alt="image1074.png" width="0.88in"}`images/12-user-interface-elements/image1074.png`
 
 What’s new here is the result pic… option.
 It’s like script pic… but it includes in the picture a speech balloon
@@ -1144,7 +1144,7 @@ that broadcast the same message.
 
 Control-click/right-click on the grey striped background of the scripting area gives this menu:
 
-![image1075.png](images/12-user-interface-elements/image1075.png) <!--  style="width:1.28958in;height:1.27778in" / -->
+{img alt="image1075.png" width="1.29in"}`images/12-user-interface-elements/image1075.png`
 
 The {index}`undrop option` is a sort of “undo” feature for
 the common case of dropping a block somewhere other than where you meant
@@ -1168,7 +1168,7 @@ mouse, as with duplicating scripts, so you position the mouse where you
 want the comment and click to release it. You can then edit the text in
 the comment as desired.
 
-![image1078.png](images/12-user-interface-elements/image1078.png) <!--  style="width:1.38889in;height:0.70833in" / -->
+{img alt="image1078.png" width="1.39in"}`images/12-user-interface-elements/image1078.png`
 
 
 You can drag the bottom right
@@ -1181,11 +1181,11 @@ expand one of them when you want to read it in full.
 If you drag a comment over a block in a script, the comment will be
 attached to the block with a yellow line:
 
-![image1081.png](images/12-user-interface-elements/image1081.png) <!--  style="width:3.33333in;height:0.93333in" / -->
+{img alt="image1081.png" width="3.33in"}`images/12-user-interface-elements/image1081.png`
 
 Comments have their own context menu, with obvious meanings:
 
-![image1080.png](images/12-user-interface-elements/image1080.png) <!--  style="width:1.48611in;height:0.84722in" / -->
+{img alt="image1080.png" width="1.49in"}`images/12-user-interface-elements/image1080.png`
 
 Back to the options in the menu for the background of the scripting area
 (picture on the previous page):
@@ -1223,7 +1223,7 @@ get blocks option
 If you click on the word “Costumes” under the sprite controls, you’ll see
 something like this:
 
-![image1082.png](images/12-user-interface-elements/image1082.png) <!--  style="width:1.96319in;height:2.13194in" / -->
+{img alt="image1082.png" width="1.96in"}`images/12-user-interface-elements/image1082.png`
 
 The Turtle costume is always present in every sprite; it is costume
 number 0. Other costumes can be painted within Snap<em>!</em> or imported from
@@ -1239,12 +1239,12 @@ Snap<em>!</em> permission to use the camera, and maybe only if you opened
 Snap<em>!</em> in secure (HTTPS) mode, and then only if your
 browser loves you.
 
-![image1085.png](images/12-user-interface-elements/image1085.png) <!--  style="width:3.56944in;height:3.18056in" -->
+{img alt="image1085.png" width="3.57in"}`images/12-user-interface-elements/image1085.png`
 *Brian’s bedroom when he’s staying at Paul’s house.*
 
 Control-clicking/right-clicking on the turtle picture gives this menu:
 
-![image1086.png](images/12-user-interface-elements/image1086.png) <!--  style="width:1.05556in;height:0.90278in" / -->
+{img alt="image1086.png" width="1.06in"}`images/12-user-interface-elements/image1086.png`
 
 In this menu, you choose the turtle’s *rotation point* which is
 also the point from which the turtle draws lines. The two pictures below
@@ -1253,7 +1253,7 @@ show what the stage looks like after drawing a square in each mode; tip
 the pictures below, middle (“Brian mode”) on the
 right:
 
-![image1087.png](images/12-user-interface-elements/image1087.png) <!--  style="width:1.05556in;height:0.90278in" / -->
+{img alt="image1087.png" width="3.13in"}`images/12-user-interface-elements/image1087.png`
 
 As you see, “tip” means the front tip of the arrowhead; “middle” is not
 the middle of the shaded region, but actually the middle of the four
@@ -1270,7 +1270,7 @@ style of drawing.)
 Costumes other than the
 turtle have a different context menu:
 
-![image1091.png](images/12-user-interface-elements/image1091.png) <!--  style="width:0.98333in;height:1.31944in" / -->
+{img alt="image1091.png" width="0.98in"}`images/12-user-interface-elements/image1091.png`
 
 The {index}`edit option` opens the Paint Editor on this
 costume. The {index}`rename option` opens a dialog box in
@@ -1291,7 +1291,7 @@ If you drag a *smart picture* of a script into the Costumes tab, its
 icon will display the text “\</\>” in the corner to remind you that it
 includes code:
 
-![image1088.png](images/12-user-interface-elements/image1088.png) <!--  style="width:0.98333in;height:1.31944in" / -->
+{img alt="image1088.png" width="3.13in"}`images/12-user-interface-elements/image1088.png`
 
 Its right-click menu will have an extra get blocks option that switches to the Scripts tab with the script ready to
 be dropped there.
@@ -1315,7 +1315,7 @@ edge color
 
 Here is a picture of a Paint Editor window:
 
-![The Paint Editor showing an Alonzo costume](images/12-user-interface-elements/image1094.png)
+{img alt="The Paint Editor showing an Alonzo costume" width="3.94in"}`images/12-user-interface-elements/image1094.png`
 
 If you’ve used any painting program, most of this will be familiar to
 you. Currently, costumes you import can be edited only if they are in a
@@ -1388,7 +1388,7 @@ shape up (frontward) or down (rearward) relative to other shapes. There
 is a selection tool {inline alt="image1096.png"}`images/12-user-interface-elements/image1096.png` <!--  style="width:0.21528in;height:0.21528in" / -->  to drag out a rectangular area and select all the
 shapes within that area.
 
-![image1095.png](images/12-user-interface-elements/image1095.png) <!--  style="width:3.83611in;height:2.54861in" / -->
+{img alt="image1095.png" width="3.84in"}`images/12-user-interface-elements/image1095.png`
 
 
 :::{index} controls in the Sounds tab
@@ -1404,7 +1404,7 @@ rename, delete, and export options, and it has a clickable button
 labeled Play or Stop as appropriate. There is a sound *recorder,* which
 appears if you click the red record button ({inline alt="image1099.png"}`images/12-user-interface-elements/image1099.png` <!--  style="width:0.35in;height:0.2in" --> ):
 
-![image1100.png](images/12-user-interface-elements/image1100.png) <!--  style="width:2.325in;height:1.03333in" -->
+{img alt="image1100.png" width="2.33in"}`images/12-user-interface-elements/image1100.png`
 
 The first, round button starts recording. The second, square button stops
 recording. The third, triangular button plays back a recorded sound. If
@@ -1444,7 +1444,7 @@ top of the scripting area.
 When the script editor is running, its position is represented by a
 blinking white bar:
 
-![image1101.png](images/12-user-interface-elements/image1101.png) <!--  style="width:2.20833in;height:1.59375in" / -->
+{img alt="image1101.png" width="2.21in"}`images/12-user-interface-elements/image1101.png`
 
 To leave the keyboard editor, type the escape key, or just click on the background of the scripting area.
 
@@ -1473,7 +1473,7 @@ move up or down to another command block, respectively.) Here is a
 sequence of pictures showing the results of repeated right arrow keys
 starting from the position shown above:
 
-![image1101.png](images/12-user-interface-elements/image1101.png) <!--  style="width:2.20833in;height:1.59375in" / -->
+{img alt="image1101.png" width="2.21in"}`images/12-user-interface-elements/image1101.png`
 
 You can rearrange scripts within the scripting area from the keyboard.
 Typing shift-arrow keys
@@ -1549,14 +1549,14 @@ without inserting the block. (When not in the keyboard editor, instead
 of navigating with the arrow keys, you drag the block you want into the
 script, as you would from any other palette.)
 
-![image1110.png](images/12-user-interface-elements/image1110.png) <!--  style="width:1.53472in;height:1.69444in" / -->
+{img alt="image1110.png" width="1.53in"}`images/12-user-interface-elements/image1110.png`
 
  If you type an arithmetic
 operator (+-\*/) or comparison operator (\<=\>) into the block search
 text box, you can type an arbitrarily complicated expression, and a
 collection of arithmetic operator blocks will be constructed to match:
 
-![image1111.png](images/12-user-interface-elements/image1111.png) <!--  style="width:2.83333in;height:0.84097in" / -->
+{img alt="image1111.png" width="2.83in"}`images/12-user-interface-elements/image1111.png`
 
 As the example shows, you can also use parentheses for grouping, and
 non-numeric operands are treated as variables or primitive functions. (A
@@ -1591,7 +1591,7 @@ export option
 Most sprites can be moved by clicking and dragging them. (If you have unchecked the draggable
 checkbox for a sprite, then dragging it has no effect.) Control-clicking/right-clicking a sprite shows this context menu:
 
-![image1112.png](images/12-user-interface-elements/image1112.png) <!--  style="width:0.60139in;height:1.08333in" / -->
+{img alt="image1112.png" width="0.60in"}`images/12-user-interface-elements/image1112.png`
 
 The {index}`duplicate option` makes another sprite with
 copies of the same scripts, same costumes, etc., as this sprite. The new
@@ -1612,7 +1612,7 @@ The move
 option shows a “move handle” inside the sprite (the
 diagonal striped square in the middle):
 
-![image1113.png](images/12-user-interface-elements/image1113.png) <!--  style="width:0.65278in;height:0.88889in" -->
+{img alt="image1113.png" width="0.65in"}`images/12-user-interface-elements/image1113.png`
 
 You can ordinarily just grab and move the sprite without this option,
 but there are two reasons you might need it: First, it works even if the
@@ -1622,7 +1622,7 @@ part moves the entire nested sprite.
 
 The rotate option displays a rotation menu:
 
-![image1114.png](images/12-user-interface-elements/image1114.png) <!--  style="width:0.93333in;height:1.58333in" / -->
+{img alt="image1114.png" width="0.93in"}`images/12-user-interface-elements/image1114.png`
 
 You can choose one of the
 four compass directions in the lower part (the same as in the point in
@@ -1632,7 +1632,7 @@ direction block) or use the mouse to rotate the handle on the dial in
 The pivot
 option shows a crosshair inside the sprite:
 
-![image1115.png](images/12-user-interface-elements/image1115.png) <!--  style="width:0.65278in;height:0.84722in" -->
+{img alt="image1115.png" width="0.65in"}`images/12-user-interface-elements/image1115.png`
 
 You can click and drag the crosshair anywhere onstage to set the
 costume’s pivot point. (If you move it outside the sprite, then turning
@@ -1671,12 +1671,12 @@ export… option
 
 Right-clicking on a variable watcher shows this menu:
 
-![image1116.png](images/12-user-interface-elements/image1116.png) <!--  style="width:0.95833in;height:1.44792in" -->
+{img alt="image1116.png" width="0.96in"}`images/12-user-interface-elements/image1116.png`
 
 The first section of the menu lets you choose one of three
 visualizations of the watcher:
 
-![image1117.png](images/12-user-interface-elements/image1117.png) <!--  style="width:0.95833in;height:1.44792in" -->
+{img alt="image1117.png" width="2.32in"}`images/12-user-interface-elements/image1117.png`
 
 The first (normal) visualization is for debugging.
 The second (large) is for displaying information to
@@ -1726,7 +1726,7 @@ Control-clicking/right-clicking on the stage background (that is,
 anywhere on the stage except on a sprite or watcher) shows the stage’s
 own context menu:
 
-![image1123.png](images/12-user-interface-elements/image1123.png) <!--  style="width:0.82153in;height:0.84722in" / -->
+{img alt="image1123.png" width="0.82in"}`images/12-user-interface-elements/image1123.png`
 
 The stage’s edit option selects the stage, so the stage’s scripts and
 backgrounds are seen in the scripting area. Note that when the stage is
@@ -1793,7 +1793,7 @@ the stage.
 You can right-click/control-click a sprite’s thumbnail to get this
 context menu:
 
-![image1127.png](images/12-user-interface-elements/image1127.png) <!--  style="width:0.67708in;height:1.10903in" / -->
+{img alt="image1127.png" width="0.68in"}`images/12-user-interface-elements/image1127.png`
 
 The show option makes the sprite visible, if it was hidden, and also brings it
 onto the stage, if it had moved past the stage boundary. The next three
@@ -1817,7 +1817,7 @@ If pen trails are being logged, there will also be an svg… option.
 If your project includes scenes, then under the stage
 icon in the sprite corral will be the *scene corral:*
 
-![image1128.png](images/12-user-interface-elements/image1128.png) <!--  style="width:3.33333in;height:1.70833in" -->
+{img alt="image1128.png" width="3.33in"}`images/12-user-interface-elements/image1128.png`
 
 Clicking on a scene will select it; right-clicking will present a menu in which you
 can rename, delete, or export the scene.

--- a/12-user-interface-elements.md
+++ b/12-user-interface-elements.md
@@ -168,9 +168,9 @@ private and nobody can see it except you, its owner. If it is shared
 (**boldface** in the project list), then when you open it you’ll see a URL
 like this one:
 
-{span .mono}[https://snap.berkeley.edu/snapsource/snap.html#present:Username=bh&ProjectName=count%20change](https://snap.berkeley.edu/snapsource/snap.html#present:Username=bh&ProjectName=count%20change)
+{span .mono}`https://snap.berkeley.edu/snapsource/snap.html#present:Username=bh&ProjectName=count%20change`(https://snap.berkeley.edu/snapsource/snap.html#present:Username=bh&ProjectName=count%20change)
 
-but with your username and project name. (“{span .mono}[`%20`]” in the project name
+but with your username and project name. (“{span .mono}``%20``” in the project name
 represents a space, which can’t be part of a URL.) Anyone who knows this
 URL can see your project. Finally, if your project is published (**_bold
 italic_** in the list), then your project is shown on the Snap<em>!</em> web

--- a/12-user-interface-elements.md
+++ b/12-user-interface-elements.md
@@ -625,8 +625,8 @@ the project “Codification” in the Examples project list. Edit the blocks
 map to Smalltalk, map to JavaScript, etc., to see examples of how to
 provide translations for blocks.
 
-![image1028.png](images/12-user-interface-elements/image1028.png){ .image-4x } <!--  style="width:1.38in;height:4.79in" alt="Graphical user interface, application, Teams Description automatically generated" / -->
-{inline alt="image1027.png" class="image-4x "}`images/12-user-interface-elements/image1027.png` <!--  style="width:2.20972in;height:4.96944in" -->
+![image1028.png](images/12-user-interface-elements/image1028.png) <!--  style="width:1.38in;height:4.79in" alt="Graphical user interface, application, Teams Description automatically generated" / -->
+{img alt="image1027.png" class="image-4x"}`images/12-user-interface-elements/image1027.png` <!--  style="width:2.20972in;height:4.96944in" -->
 
 The Single palette option puts all blocks,
 regardless of category, into a single palette. It’s intended mainly for

--- a/_support/plugins/latex-shims.mjs
+++ b/_support/plugins/latex-shims.mjs
@@ -148,6 +148,37 @@ function quoteForMakeindex(s) {
 // which is defined in the preamble (the body font has no glyph for
 // ⚡, so passing it through verbatim renders as a missing-glyph box).
 
+// Symbol-to-ASCII map used when building the makeindex sort key for an
+// entry that contains non-ASCII characters. makeindex is byte-oriented
+// and treats every UTF-8 lead byte (0x80-0xFF) as the same alphabet
+// "letter" group, so an entry like "≤ block" creates a singleton group
+// whose heading is the partial UTF-8 sequence of ≤. LuaTeX then chokes
+// reading the .ind file ("String contains an invalid utf-8 sequence"),
+// which leaves \textbf{ unclosed and ends the index `multicols` early.
+// Translating known symbols to a stable ASCII name in the sort key
+// keeps the printed display untouched while putting the entry in a
+// real letter group.
+const INDEX_SORT_REPLACEMENTS = [
+  [/⚡️?/g, 'lightning bolt'],
+  [/≤/g, 'less or equal'],
+  [/≥/g, 'greater or equal'],
+  [/➔/g, 'arrow'],
+  [/…/g, '...'],
+  [/[“”]/g, '"'],
+  [/[‘’]/g, "'"],
+  [/—/g, '-'],
+  [/–/g, '-'],
+];
+
+function asciiSortKey(value) {
+  let out = value;
+  for (const [re, rep] of INDEX_SORT_REPLACEMENTS) out = out.replace(re, rep);
+  // Strip anything still outside ASCII so makeindex sorts on a clean
+  // single-byte string. Collapse whitespace introduced by the replacement.
+  out = out.replace(/[^\x20-\x7e]/g, '').replace(/\s+/g, ' ').trim();
+  return out;
+}
+
 function rewriteIndexEntry(value) {
   if (typeof value !== 'string') return value;
   // Trailing backslashes on index entries (sometimes left over from
@@ -157,55 +188,82 @@ function rewriteIndexEntry(value) {
   // an index term.
   value = value.replace(/\\+\s*$/, '').trim();
   const hasCode = value.includes('`');
-  const hasBolt = /[⚡]/.test(value);
-  if (!hasCode && !hasBolt) return value;
+  const hasNonAscii = /[^\x00-\x7f]/.test(value);
+  if (!hasCode && !hasNonAscii) return value;
   // Display: `set` -> \texttt{set}; ⚡ (with optional VS-16) -> \snaplightning{}.
   // # / % / & are parameter / comment / tab-alignment characters in LaTeX
   // and would break the .ind file makeindex emits if left bare inside the
   // \texttt{...} group. _ is already typically escaped by myst upstream
   // but we double-escape defensively.
+  // Display-side rewrites: render `code` as \texttt{...}; map symbols
+  // that have no glyph in the body font (Source Serif Pro) to a TeX
+  // command that does — \snaplightning{} for ⚡, \textrightarrow{} for
+  // the ➔ found in block names like `sentence ➔ list`. Without these
+  // the .ind file would render a missing-glyph box for those symbols.
   const display = quoteForMakeindex(
     value
       .replace(/`([^`]+)`/g, (_m, code) =>
         `\\texttt{${code.replace(/(?<!\\)([#%&_])/g, '\\$1')}}`,
       )
-      .replace(/⚡️?/g, '\\snaplightning{}'),
+      .replace(/⚡️?/g, '\\snaplightning{}')
+      .replace(/➔/g, '\\textrightarrow{}'),
   );
-  // Sort key: drop the formatting markers entirely, collapse the
-  // resulting whitespace, and substitute "lightning bolt" for ⚡ so
-  // the entry alphabetizes near "L" rather than the symbol section.
+  // Sort key: drop formatting markers, translate known symbols to ASCII
+  // names so they alphabetize sensibly, and strip anything else outside
+  // ASCII so makeindex doesn't make a bogus single-byte letter group.
   const sort = quoteForMakeindex(
-    value
-      .replace(/`/g, '')
-      .replace(/⚡️?\s*/g, 'lightning bolt ')
-      .replace(/\s+/g, ' ')
-      .trim(),
+    asciiSortKey(value.replace(/`/g, '')),
   );
   return `${sort}@${display}`;
 }
 
-// Replace ⚡ (with optional VS-16) inside a text node with raw TeX
-// pointing at \snaplightning. Returns either the original node, a
-// single replacement, or an array of nodes when the bolt appears
-// in the middle of a longer string.
-function expandLightningInTextNode(node) {
+// Symbols that have no glyph in the body fonts (Source Serif Pro,
+// Latin Modern Mono) and therefore render as a missing-character box
+// in the PDF. Each entry maps the source character (with an optional
+// trailing variation selector U+FE0F) to a TeX command that renders
+// something visually equivalent in any body font.
+const BODY_SYMBOL_MAP = [
+  { re: /⚡️?/g, tex: '\\snaplightning{}' },
+  { re: /➔/g,    tex: '\\textrightarrow{}' },
+];
+
+const BODY_SYMBOL_RE = new RegExp(
+  BODY_SYMBOL_MAP.map((s) => s.re.source).join('|'),
+  'g',
+);
+
+// Replace symbols that have no body-font glyph inside a text node with
+// raw TeX commands. Returns either null (no change), or an array of
+// replacement nodes when a symbol appears in the middle of a string.
+function expandSymbolsInTextNode(node) {
   if (node.type !== 'text' || typeof node.value !== 'string') return null;
-  if (!/[⚡]/.test(node.value)) return null;
-  const parts = node.value.split(/⚡️?/);
+  if (!BODY_SYMBOL_RE.test(node.value)) return null;
+  // BODY_SYMBOL_RE is global; reset state before splitting per-symbol.
+  BODY_SYMBOL_RE.lastIndex = 0;
   const out = [];
-  parts.forEach((part, idx) => {
-    if (part) out.push({ type: 'text', value: part });
-    if (idx < parts.length - 1) {
-      out.push({ type: 'raw', lang: 'tex', tex: '\\snaplightning{}' });
+  let cursor = 0;
+  for (const m of node.value.matchAll(BODY_SYMBOL_RE)) {
+    if (m.index > cursor) {
+      out.push({ type: 'text', value: node.value.slice(cursor, m.index) });
     }
-  });
+    const matched = m[0];
+    const entry = BODY_SYMBOL_MAP.find((s) => {
+      s.re.lastIndex = 0;
+      return s.re.test(matched);
+    });
+    out.push({ type: 'raw', lang: 'tex', tex: entry?.tex ?? matched });
+    cursor = m.index + matched.length;
+  }
+  if (cursor < node.value.length) {
+    out.push({ type: 'text', value: node.value.slice(cursor) });
+  }
   return out;
 }
 
-function rewriteLightningInChildren(parent) {
+function rewriteSymbolsInChildren(parent) {
   if (!Array.isArray(parent.children)) return;
   for (let i = 0; i < parent.children.length; i++) {
-    const replacement = expandLightningInTextNode(parent.children[i]);
+    const replacement = expandSymbolsInTextNode(parent.children[i]);
     if (replacement) {
       parent.children.splice(i, 1, ...replacement);
       i += replacement.length - 1;
@@ -297,11 +355,11 @@ const latexShimsTransform = {
       });
     });
 
-    // 4. Lightning bolt in body text. Source Serif Pro has no glyph
-    //    for ⚡, so we splice in a \snaplightning{} raw-TeX node
-    //    wherever the emoji appears. Index-entry strings were already
-    //    handled above.
-    walkAll(tree, (node) => rewriteLightningInChildren(node));
+    // 4. Body-font symbol substitutions. Source Serif Pro and Latin
+    //    Modern Mono have no glyph for the ⚡ and ➔ symbols Snap! uses
+    //    in block names, so we splice in raw-TeX nodes wherever they
+    //    appear. Index-entry strings were already handled above.
+    walkAll(tree, (node) => rewriteSymbolsInChildren(node));
 
     // 5. Image sizing.
     //    Inline images get a sentinel width that the custom \includegraphics

--- a/_support/scripts/apply-docx-widths.py
+++ b/_support/scripts/apply-docx-widths.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Backport docx-derived image widths into plain ``![](path)`` markdown images.
+
+The original `convert-word-doc.rb` pipeline strips Pandoc's
+``{width="Xin" height="Yin"}`` attributes from images during the
+docx → markdown conversion (it moves them into non-functional HTML
+comments or drops them entirely). As a result, plain block images in
+the chapter `.md` files fall through to the latex-shims default of
+30 % of \\linewidth — too small for editor screenshots that were
+~5 in. wide in the docx, and too large for ~1 in. block icons.
+
+This script harvests the original widths from the docx-as-markdown
+export at ``_support/conversion/SnapManual.md`` and re-attaches them
+to the chapter markdown by rewriting plain block images as the
+project-local ``{img}`` role (see ``_support/plugins/img-role.mjs``).
+The latex-shims plugin's ``normalizeWidth`` already converts ``Xin``
+widths to a percentage of \\linewidth, so the role works through the
+existing pipeline without further changes.
+
+Usage::
+
+    cd /path/to/manual
+    python3 _support/scripts/apply-docx-widths.py
+
+The script is idempotent: images that already use ``{img}``,
+``{inline}``, or any other role are left alone.
+
+Heuristics:
+- Only touches block images whose entire line is ``![alt](url)``
+  (with optional title and trailing HTML comment).
+- Skips images whose URL doesn't look like a docx-extracted
+  ``imageNN.png`` (no entry in the width map).
+- For images reused at multiple sizes in the docx, picks the largest
+  recorded width (smaller copies are usually inline thumbnails that
+  belong on the inline-role path anyway).
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+DOCX = REPO / "_support" / "conversion" / "SnapManual.docx"
+
+DOCX_IMG = re.compile(
+    r"!\[[^\]]*\]\([^)]*?(image\d+)\.png\)\{width=\"([\d.]+)in\""
+)
+
+
+def extract_docx_markdown() -> str:
+    """Return the docx contents as Pandoc-flavoured markdown.
+
+    Uses the same `pandoc --from docx --to markdown` conversion as
+    ``convert-word-doc.rb`` so the resulting image attributes line up
+    with what that script sees, but keeps everything in a temp dir to
+    avoid leaving generated files in the tree.
+    """
+    if not DOCX.exists():
+        sys.exit(f"Missing {DOCX} — nothing to harvest widths from.")
+    if shutil.which("pandoc") is None:
+        sys.exit(
+            "pandoc not found on PATH. Install pandoc (the same tool the "
+            "convert-word-doc.rb pipeline relies on) and re-run."
+        )
+    with tempfile.TemporaryDirectory() as tmp:
+        out = Path(tmp) / "SnapManual.md"
+        subprocess.run(
+            [
+                "pandoc",
+                "--from",
+                "docx",
+                str(DOCX),
+                "--to",
+                "markdown",
+                "--wrap=none",
+                "-o",
+                str(out),
+            ],
+            check=True,
+            cwd=tmp,
+        )
+        return out.read_text(encoding="utf-8")
+
+
+def build_docx_width_map() -> dict[str, float]:
+    text = extract_docx_markdown()
+    widths: dict[str, float] = {}
+    for m in DOCX_IMG.finditer(text):
+        name, width = m.group(1), float(m.group(2))
+        if name not in widths or width > widths[name]:
+            widths[name] = width
+    return widths
+
+
+PLAIN_BLOCK_IMG = re.compile(
+    r"^(?P<indent>[ \t]*)"
+    r"!\[(?P<alt>[^\]]*)\]"
+    r"\((?P<url>[^)\s]+)(?:\s+\"(?P<title>[^\"]*)\")?\)"
+    r"(?P<trailing>[ \t]*(?:<!--[^>]*-->[ \t]*)?)$",
+    re.MULTILINE,
+)
+URL_IMAGE_NN = re.compile(r"/(image\d+)\.(?:png|jpg|jpeg|gif)$", re.IGNORECASE)
+
+
+def quote(value: str) -> str:
+    return value.replace('"', '\\"')
+
+
+def apply_widths(md_path: Path, widths: dict[str, float]) -> int:
+    text = md_path.read_text(encoding="utf-8")
+    changed = 0
+
+    def repl(m: re.Match) -> str:
+        nonlocal changed
+        url = m.group("url")
+        url_match = URL_IMAGE_NN.search(url)
+        if not url_match:
+            return m.group(0)
+        image_name = url_match.group(1)
+        width = widths.get(image_name)
+        if width is None or width <= 0:
+            return m.group(0)
+        alt = m.group("alt") or image_name
+        title = m.group("title")
+        opts = [f'alt="{quote(alt)}"', f'width="{width:.2f}in"']
+        if title:
+            opts.append(f'title="{quote(title)}"')
+        changed += 1
+        return f'{m.group("indent")}{{img {" ".join(opts)}}}`{url}`'
+
+    new_text = PLAIN_BLOCK_IMG.sub(repl, text)
+    if changed:
+        md_path.write_text(new_text, encoding="utf-8")
+    return changed
+
+
+def main() -> None:
+    widths = build_docx_width_map()
+    print(f"Loaded {len(widths)} docx image widths.", file=sys.stderr)
+    targets = sorted(REPO.glob("[0-9][0-9]-*.md")) + sorted(
+        REPO.glob("appendix/*.md")
+    )
+    total = 0
+    for md in targets:
+        n = apply_widths(md, widths)
+        if n:
+            print(f"  {md.relative_to(REPO)}: {n} image widths set")
+        total += n
+    print(f"Total updated: {total}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/_support/styles/snap-manual.scss
+++ b/_support/styles/snap-manual.scss
@@ -97,29 +97,25 @@ html.dark .menu-text code {
 // TODO: make latex env
 .image-1-5x {
   &, img {
-    height: 70%;
-    width: auto;
+    width: 70%;
   }
 }
 
 .image-2x {
   &, img {
-    height: 50%;
-    width: auto;
+    width: 50%;
   }
 }
 
 .image-3x {
     &, img {
-    height: 33.33%;
-    width: auto;
+    width: 33.33%;
   }
 }
 
 .image-4x {
   &, img {
-    height: 25%;
-    width: auto;
+    width: 25%;
   }
 }
 

--- a/appendix/a-snap-color-library.md
+++ b/appendix/a-snap-color-library.md
@@ -14,7 +14,7 @@ provides several tools for manipulating color. Although its main purpose
 is controlling a sprite’s pen color, it also establishes colors as a
 first class data type:
 
-![image401.png](images/a-snap-color-library/image401.png)
+{img alt="image401.png" width="7.28in"}`images/a-snap-color-library/image401.png`
 
 For people who just want colors in their projects without having to be color experts, we
 provide two simple mechanisms: a *color number*
@@ -22,12 +22,12 @@ scale with a broad range of continuous color variation and a set of 100
 *crayons* organized by color family (ten reds, ten oranges, etc.) The
 crayons include the block colors:
 
-![image1135.png](images/a-snap-color-library/image1135.png)
+{img alt="image1135.png" width="3.13in"}`images/a-snap-color-library/image1135.png`
 
 
 For experts, we provide color selection by RGB, HSL, HSV, X11/W3C names, and variants on those scales.
 
-![image1136.png](images/a-snap-color-library/image1136.png) <!--  style="width:7.16667in;height:1.1in" -->
+{img alt="image1136.png" width="7.17in"}`images/a-snap-color-library/image1136.png`
 
 :::{index} RGB
 CMY
@@ -127,12 +127,12 @@ know the crayon name, just {inline alt="image1147.png"}`images/a-snap-color-libr
 
 The crayon numbers are chosen so that skipping by 10 gives a sensible box of ten crayons:
 
-![image1154.png](images/a-snap-color-library/image1154.png) <!--  style="width:5.79306in;height:0.3in" / -->
+{img alt="image1154.png" width="5.79in"}`images/a-snap-color-library/image1154.png`
 
 Alternatively, skipping by 5 gives a still-sensible set of twenty
 crayons:
 
-![image1155.png](images/a-snap-color-library/image1155.png) <!--  style="width:5.8in;height:0.3in" / -->
+{img alt="image1155.png" width="5.80in"}`images/a-snap-color-library/image1155.png`
 
 The set of *color numbers* is arranged so that each color number is
 visually near each of its neighbors. Bright and dark colors alternate
@@ -140,7 +140,7 @@ for each family. {index}`Color numbers` range from 0 to 99,
 like crayon numbers, but you can use fractional numbers to get as tiny a
 step as you like:
 
-![image1141.png](images/a-snap-color-library/image1141.png) <!--  style="width:5.79306in;height:0.3in" / -->
+{img alt="image1141.png" width="6.00in"}`images/a-snap-color-library/image1141.png`
 
 (“As tiny as you like” isn’t *quite* true because in the end, your color
 has to be rounded to integer RGB values for display.)
@@ -163,7 +163,7 @@ data type.
 There are three library blocks specifically about controlling the pen.
 They have the same names as three of the primitive Pen blocks:
 
-![image1156.png](images/a-snap-color-library/image1156.png) <!--  style="width:5.79306in;height:0.3in" / -->
+{img alt="image1156.png" width="6.25in"}`images/a-snap-color-library/image1156.png`
 
 The first (Pen block-colored) input slot is used to select which color
 scale you want to use. (These blocks also allow reading or setting two
@@ -187,7 +187,7 @@ The set pen block changes the pen color to the
 value(s) you specify. The meaning of the white input slots depends on
 which attribute of the pen you’re setting:
 
-![image1158.png](images/a-snap-color-library/image1158.png) <!--  style="width:5.79306in;height:0.3in" / -->
+{img alt="image1158.png" width="6.07in"}`images/a-snap-color-library/image1158.png`
 
 In the last example, the number 37 sets the *transparency,* on the scale
 0=opaque, 100=invisible. (All color attributes are on a 0–100 scale
@@ -198,7 +198,7 @@ scales.
 The library also includes two constructors and a selector for colors as
 a data type:
 
-![image1159.png](images/a-snap-color-library/image1159.png) <!--  style="width:5.79306in;height:0.3in" / -->
+{img alt="image1159.png" width="6.07in"}`images/a-snap-color-library/image1159.png`
 
 The latter two
 are inverses of each other, translating between colors and their
@@ -214,7 +214,7 @@ small subset of the millions of colors your computer can generate.) If
 you have a color and want another color that’s the same except for one
 number, as in the Red example, you can use this block:
 
-![image402.png](images/a-snap-color-library/image402.png) <!--  style="width:1.80556in;height:0.19444in" -->
+{img alt="image402.png" width="7.28in"}`images/a-snap-color-library/image402.png`
 
 Finally, the library includes the {index}`mix block` and a
 helper:
@@ -235,7 +235,7 @@ of “hue,” which more or less means where a color would
 appear in a rainbow (magenta, near the
 right, is [a long story](https://en.wikipedia.org/wiki/Magenta)):
 
-![image1189.png](images/a-snap-color-library/image1189.png) <!--  style="width:5.80667in;height:0.30667in" / -->
+{img alt="image1189.png" width="5.81in"}`images/a-snap-color-library/image1189.png`
 
 These are called “spectral ” colors, after the
 *spectrum* of rainbow colors. But these colors aren’t equally
@@ -262,9 +262,9 @@ layout. But for amateurs using a simplified, one-dimensional color
 model, there’s no reason not to use a more programmer-friendly hue
 scale:
 
-![image1190.png](images/a-snap-color-library/image1190.png) <!--  style="width:5.99444in;height:0.29931in" / -->
+{img alt="image1190.png" width="5.99in"}`images/a-snap-color-library/image1190.png`
 
-![image1191.png](images/a-snap-color-library/image1191.png) <!--  style="width:1.45972in;height:1.35833in" / -->
+{img alt="image1191.png" width="1.46in"}`images/a-snap-color-library/image1191.png`
 
 In this scale, each of the
 seven rainbow colors and brown get an equal share. (Red’s looks too
@@ -319,13 +319,17 @@ every-tenth-crayon selections don’t include it, so that all of the
 crayons in those smaller boxes are visible against a white
 stage background.
 
-::: {.evenly-spaced-images layout-ncol="2"}
-![(attribution: Wikipedia user Andys. CC BY-SA.)](images/a-snap-color-library/image1198.png "(attribution: Wikipedia user Andys. CC BY-SA.)"){#fig-rainbow}
-
+::::{grid} 2
+:::{grid-item}
+(fig-rainbow)=
+{img alt="(attribution: Wikipedia user Andys. CC BY-SA.)" width="1.85in" title="(attribution: Wikipedia user Andys. CC BY-SA.)"}`images/a-snap-color-library/image1198.png`
+:::
+:::{grid-item}
 Among purples, the official spectral violet
 (crayon 90) is the end of the spectrum. Magenta, brighter than violet, isn’t a spectral color at all.
 (In the picture at the left, the top part is the spectrum of white light spread out through a prism; the middle part is a photograph of a rainbow, and the bottom part is a digital simulation of a rainbow.) Magenta is a mixture of red and blue.
 :::
+::::
 
 The light gray at color number 10 is slightly different from crayon 10
 just because of roundoff in computing crayon values. Color number 90 is
@@ -374,7 +378,7 @@ L\*a\*b\*
 
 ### Perceptual Spaces: HSV and HSL
 
-![image1199.png](images/a-snap-color-library/image1199.png) <!--  style="width:0.73611in;height:0.72222in" -->
+{img alt="image1199.png" width="0.74in"}`images/a-snap-color-library/image1199.png`
 
 RGB is the right way to
 think about colors if you’re building or programming a display monitor;
@@ -389,7 +393,7 @@ blue in the top right corner. Although no other point in the square is
 pure blue, you can tell at a glance that no other spectral color is
 mixed with the blue.
 
-![image1200.png](images/a-snap-color-library/image1200.png) <!--  style="width:2.69167in;height:1.19028in" / -->
+{img alt="image1200.png" width="2.69in"}`images/a-snap-color-library/image1200.png`
 attribution: Wikipedia user SharkD, CC BY-SA 3.0
 
 Aside from hue, the other two dimensions of a color space have to represent how much white and/or
@@ -417,7 +421,7 @@ But if you’re looking at colors on a computer display, HSV isn’t really a go
 perception. Intuitively, black and white should be treated
 symmetrically. This is the HSL (hue-saturation-lightness) color space.
 
-![image1203.png](images/a-snap-color-library/image1203.png) <!--  style="width:0.76389in;height:0.76389in" -->
+{img alt="image1203.png" width="0.76in"}`images/a-snap-color-library/image1203.png`
 
 *Saturation,* in HSL, is a measure of the *grayness* or *dullness* of a color (how close it comes to being on a black-and-white scale) and *lightness* measures *spectralness* with
 pure white at one end, pure black at the other end, and spectral color
@@ -453,7 +457,7 @@ standardization committee. I learned all this from [this
 tutorial](http://www.huevaluechroma.com/011.php), which you might find
 more coherent than jumping around Wikipedia if you’re interested.
 
-![image1204.png](images/a-snap-color-library/image1204.png) <!--  style="width:1.64375in;height:0.84167in" / -->
+{img alt="image1204.png" width="1.64in"}`images/a-snap-color-library/image1204.png`
 
 Although traditional Scratch
 and Snap<em>!</em> use HSV in programs, they use HSL in the color picker.
@@ -515,7 +519,7 @@ then *all three* values must be reduced by half, so the result is (255,
 128, 0), which is orange. (Half of 255 is 127.5, but each RGB value must
 be an integer.)
 
-![image1207.png](images/a-snap-color-library/image1207.png) <!--  style="width:0.20278in;height:0.20278in" / -->
+{img alt="image1207.png" width="4.35in"}`images/a-snap-color-library/image1207.png`
 
 A different kind of color mixing based on light is done when different
 colored transparent plastic sheets are held in front of a white light,
@@ -528,7 +532,7 @@ But there isn’t any green light for the yellow filter to pass; it was
 filtered out by the red filter. Each filter can only remove light, not
 add light, so this is called *subtractive* mixing:
 
-![image1208.png](images/a-snap-color-library/image1208.png) <!--  style="width:0.20278in;height:0.20278in" / -->
+{img alt="image1208.png" width="4.35in"}`images/a-snap-color-library/image1208.png`
 
 Perhaps confusingly, the numerical computation of subtractive mixing
 is done by *multiplying* the RGB values,
@@ -580,13 +584,13 @@ accept any number of colors, and will mix them in equal proportion. If
 the color at weight block to make a
 “weighted color”:
 
-![image1232.png](images/a-snap-color-library/image1232.png) <!--  style="width:5.16667in;height:0.43056in" -->
+{img alt="image1232.png" width="5.17in"}`images/a-snap-color-library/image1232.png`
 
 This mixes four
 parts red paint to one part green paint. All colors in a mixture can be
 weighted:
 
-![image1231.png](images/a-snap-color-library/image1231.png) <!--  style="width:4.34028in;height:0.65278in" -->
+{img alt="image1231.png" width="4.34in"}`images/a-snap-color-library/image1231.png`
 
 (Thanks to [{index}`Scott Burns<single: Burns, Scott>`
 ](http://scottburns.us/subtractive-color-mixture/) for his help in
@@ -609,7 +613,7 @@ the latter two. We recommend “{index}`fair HSL` ” for zeroing in on a desire
 <!-- ![image1241.png](images/a-snap-color-library/image1241.png) -->
 
 (sec-spirals)=
-![image1242.png](images/a-snap-color-library/image1242.png)
+{img alt="image1242.png" width="2.21in"}`images/a-snap-color-library/image1242.png`
 
 :::{index} fair hue
 fair value
@@ -618,7 +622,7 @@ fair hue table
 
 ### Subappendix: Geeky details on fair hue
 
-![image1243.png](images/a-snap-color-library/image1243.png)
+{img alt="image1243.png" width="2.21in"}`images/a-snap-color-library/image1243.png`
 
 The left graph shows that, unsurprisingly, all of the brown fair hue
 s make essentially no progress in real hue, with the
@@ -666,15 +670,15 @@ so on.
 
 For the extra-geeky, here are the exact table lookup points (fair hue, \[0,100\]):
 
-![image1258.png](images/a-snap-color-library/image1258.png) <!--  style="width:5.9875in;height:0.37847in" / -->
+{img alt="image1258.png" width="5.99in"}`images/a-snap-color-library/image1258.png`
 
 and here are the RGB settings at those points:
 
-![image1259.png](images/a-snap-color-library/image1259.png) <!--  style="width:5.98403in;height:1.37361in" / -->
+{img alt="image1259.png" width="5.98in"}`images/a-snap-color-library/image1259.png`
 
 ### Subappendix: Geeky details on color numbers
 
-![image1260.png](images/a-snap-color-library/image1260.png) <!--  style="width:2.08333in;height:2.29167in" -->
+{img alt="image1260.png" width="2.08in"}`images/a-snap-color-library/image1260.png`
 
 Here is a picture of integer color numbers, but remember that color numbers are continuous.
 (As usual, “continuous” values are ultimately converted to integer RGB
@@ -715,7 +719,7 @@ In the color {index}`number chart`, all the dark color
 numbers look a lot like black, but they’re quite different. Here are the
 darkest colors in each color number family.
 
-![image1261.png](images/a-snap-color-library/image1261.png) <!--  style="width:1.38889in;height:1.38889in" -->
+{img alt="image1261.png" width="1.39in"}`images/a-snap-color-library/image1261.png`
 
 Darkest yellow doesn’t
 look entirely yellow. You might see it as greenish or brownish. As it
@@ -753,7 +757,7 @@ color number 87.5 is the darkest one that’s still unambiguously purple.
 Here are the reference points for color numbers that are multiples of
 five, except for item 4, which is used for color 14, not color 15:
 
-![image1262.png](images/a-snap-color-library/image1262.png) <!--  style="width:4.58333in;height:1.27778in" / -->
+{img alt="image1262.png" width="4.58in"}`images/a-snap-color-library/image1262.png`
 
 The very pale three-input list blocks are for color numbers that are odd
 multiples of five, generally the “darkest” members of each color family.

--- a/appendix/b-apl-features.md
+++ b/appendix/b-apl-features.md
@@ -214,7 +214,7 @@ roll block
 
 ### Scalar functions
 
-![image1265.png](images/b-apl-features/image1265.png) <!--  style="width:5.73333in;height:1.10667in" / -->
+{img alt="image1265.png" width="5.73in"}`images/b-apl-features/image1265.png`
 
 These are the
 {index}`scalar functions` in the APL library. Most of
@@ -265,7 +265,7 @@ columns of the input. And so on for higher dimensions. If the input
 isn’t a list at all, then it has zero dimensions, and shape of reports
 an empty vector. Equivalent to the dimensions of primitive, as of 6.6.
 
-![image1267.png](images/b-apl-features/image1267.png) <!--  style="width:4.275in;height:1.1in" -->
+{img alt="image1267.png" width="4.28in"}`images/b-apl-features/image1267.png`
 
 ![image1269.png](images/b-apl-features/image1269.png) <!--  style="width:1.04167in;height:0.18333in" --> Rank of
 isn’t an actual APL primitive, but the composition ⍴⍴
@@ -275,7 +275,7 @@ omit. (It’s very easy to type the same character twice on the APL
 keyboard, but less easy to drag blocks together.) Equivalent to the rank
 of primitive, as of 6.6.
 
-![image1270.png](images/b-apl-features/image1270.png) <!--  style="width:2.03333in;height:0.18333in" -->
+{img alt="image1270.png" width="2.03in"}`images/b-apl-features/image1270.png`
 
 Reshape
 takes a shape vector (such as shape might report)
@@ -286,7 +286,7 @@ second row, etc.). (The primitive reshape takes the inputs in the other
 order.) It then reports an array with the shape specified by the first
 input containing the items of the second:
 
-![image1271.png](images/b-apl-features/image1271.png) <!--  style="width:7.325in;height:0.83333in" -->
+{img alt="image1271.png" width="7.33in"}`images/b-apl-features/image1271.png`
 
 If the right
 input has more atomic elements than are required by the left-input shape
@@ -297,9 +297,9 @@ specific case of an atomic right input, which produces an array of any
 desired shape all of whose atomic elements are equal. But other cases
 are sometimes useful too:
 
-![image1272.png](images/b-apl-features/image1272.png) <!--  style="width:6.575in;height:1.04167in" -->
+{img alt="image1272.png" width="6.58in"}`images/b-apl-features/image1272.png`
 
-![image1273.png](images/b-apl-features/image1273.png) <!--  style="width:6.575in;height:1.04167in" -->
+{img alt="image1273.png" width="5.51in"}`images/b-apl-features/image1273.png`
 
 ![image1275.png](images/b-apl-features/image1275.png) <!--  style="width:1.43333in;height:0.18333in" --> Flatten takes an arbitrary structure as input and reports a vector of its
 atomic elements in row-major order. Lispians call this flattening the
@@ -311,7 +311,7 @@ to apply this to a scalar in order to turn it into a one-element vector,
 but we can’t use it that way because you can’t type a scalar value into
 the List-type input slot. Equivalent to the primitive flatten of block.
 
-![image1276.png](images/b-apl-features/image1276.png) <!--  style="width:1.43333in;height:0.18333in" -->
+{img alt="image1276.png" width="3.36in"}`images/b-apl-features/image1276.png`
 
 Catenate
 is like our primitive append, with two
@@ -319,13 +319,13 @@ differences: First, if either input is a scalar, it is treated like a
 one-item vector. Second, if the two inputs are of different rank, the
 catenate function is recursively mapped over the higher-rank input:
 
-![image1280.png](images/b-apl-features/image1280.png) <!--  style="width:7.20417in;height:0.58333in" -->
+{img alt="image1280.png" width="7.20in"}`images/b-apl-features/image1280.png`
 
 Catenate vertically
 is similar, but it adds new rows
 instead of adding new columns.
 
-![image1281.png](images/b-apl-features/image1281.png) <!--  style="width:0.53333in;height:0.25in" -->
+{img alt="image1281.png" width="0.53in"}`images/b-apl-features/image1281.png`
 
 Integers
 (I think that’s what it stands for, although
@@ -336,7 +336,7 @@ range. The difference between this block and the primitive numbers from
 block is in its treatment of lists as inputs. Numbers from is a
 hyperblock, applying itself to each item of its input list:
 
-![image1282.png](images/b-apl-features/image1282.png) <!--  style="width:6.34167in;height:1.04167in" -->
+{img alt="image1282.png" width="6.34in"}`images/b-apl-features/image1282.png`
 
  Iota has a special meaning for list inputs: The input must be a shape
 vector; the result is an array with that shape in which each item is a
@@ -345,7 +345,7 @@ list of the indices of the cell along each dimension. A picture is worth
 with more than two dimensions, so here we reduce each cell’s index list
 to a string:
 
-![image1283.png](images/b-apl-features/image1283.png) <!--  style="width:6.025in;height:0.83333in" -->
+{img alt="image1283.png" width="6.03in"}`images/b-apl-features/image1283.png`
 
 ![image1284.png](images/b-apl-features/image1284.png) <!--  style="width:1.475in;height:0.25in" -->  Dyadic iota is like
 the index of primitive except for its
@@ -357,7 +357,7 @@ locations of each item. If the first input is a multi-dimensional array,
 then the location of an item is a vector with the indices along each
 row.
 
-![image1285.png](images/b-apl-features/image1285.png) <!--  style="width:5.95in;height:1.1in" -->
+{img alt="image1285.png" width="5.95in"}`images/b-apl-features/image1285.png`
 
 In this example, the 4 is in the second row, second column. (This is
 actually an extension of APL iota, which is more like a hyperized index
@@ -368,7 +368,7 @@ equal to the difference between the two ranks. If the rank of the second
 input is one less than the rank of the first, the reported value is a
 scalar, the index of the entire second input in the first.
 
-![image1286.png](images/b-apl-features/image1286.png) <!--  style="width:5.84167in;height:0.35in" -->
+{img alt="image1286.png" width="5.84in"}`images/b-apl-features/image1286.png`
 
 However, if the two ranks are equal, then the block is hyperized; each
 item of the second input is located in the first input. As the next
@@ -377,13 +377,13 @@ example shows, only the first instance of each item is found (e.g., the
 the left input, what is reported is one more than the length of the left
 input (here, 8).
 
-![image1287.png](images/b-apl-features/image1287.png) <!--  style="width:5.38333in;height:1.1in" -->
+{img alt="image1287.png" width="5.38in"}`images/b-apl-features/image1287.png`
 
 Why the strange design decision to report length+1 when something isn’t
 found, instead of a more obvious flag value such as 0 or false? Here’s
 why:
 
-![image1288.png](images/b-apl-features/image1288.png) <!--  style="width:5.38333in;height:1.1in" -->
+{img alt="image1288.png" width="5.38in"}`images/b-apl-features/image1288.png`
 
 Note that code has
 27 items, not 26. The asterisk at the end is the ciphertext is the
@@ -395,7 +395,7 @@ spaces in the message so obvious. But despite being silly, the example
 shows the benefit of reporting length+1 as the position of items not
 found.
 
-![image1292.png](images/b-apl-features/image1292.png) <!--  style="width:2.175in;height:0.225in" -->
+{img alt="image1292.png" width="2.17in"}`images/b-apl-features/image1292.png`
 
 The contained in
 block is like a hyperized contains with the
@@ -403,14 +403,14 @@ input order reversed. It reports an array of Booleans the same shape as
 the left input. The shape of the right input doesn’t matter; the block
 looks only for atomic elements.
 
-![image1293.png](images/b-apl-features/image1293.png) <!--  style="width:7.48542in;height:0.65972in" -->
+{img alt="image1293.png" width="7.49in"}`images/b-apl-features/image1293.png`
 
 ![image1294.png](images/b-apl-features/image1294.png) <!--  style="width:7.48542in;height:0.65972in" -->The blocks grade up and grade down are used for sorting data. Given an array as input, it
 reports a vector of the indices in which the items (the rows, if a
 matrix) should be rearranged in order to be sorted. This will be clearer
 with an example:
 
-![image1295.png](images/b-apl-features/image1295.png) <!--  style="width:7.48542in;height:0.65972in" -->
+{img alt="image1295.png" width="2.66in"}`images/b-apl-features/image1295.png`
 
 The result from grade up tells us that item 3 of **foo** comes first in
 sorted order, then item 4, then 2, then 1. When we actually select items
@@ -424,7 +424,7 @@ Why this two-step process? Why not just have a sort primitive in APL?
 One answer is that in a database application you might want to sort one
 array based on the order of another array:
 
-![image1304.png](images/b-apl-features/image1304.png) <!--  style="width:5.48333in;height:2.2in" -->
+{img alt="image1304.png" width="5.48in"}`images/b-apl-features/image1304.png`
 
 This is the list of employees of a small company. (Taken from *Structure
 and Interpretation of Computer Programs* by Abelson and Sussman.
@@ -434,21 +434,21 @@ We would like to sort
 the employees’ names in big-to-small order of salary. First we extract
 column 3 of the database, the salaries:
 
-![image1305.png](images/b-apl-features/image1305.png) <!--  style="width:3.55903in;height:1.97639in" / -->
+{img alt="image1305.png" width="3.56in"}`images/b-apl-features/image1305.png`
 
 Then we use grade down to get the reordering indices:
 
-![image1307.png](images/b-apl-features/image1307.png) <!--  style="width:4.97847in;height:2.23333in" / -->
+{img alt="image1307.png" width="4.98in"}`images/b-apl-features/image1307.png`
 
 At this point we *could* use
 the index vector to sort the salaries:
 
-![image1306.png](images/b-apl-features/image1306.png) <!--  style="width:5.33333in;height:2.37333in" / -->
+{img alt="image1306.png" width="5.33in"}`images/b-apl-features/image1306.png`
 
 But
 what we actually want is a list of *names,* sorted by salary:
 
-![image1308.png](images/b-apl-features/image1308.png) <!--  style="width:5.59333in;height:2.3in" / -->
+{img alt="image1308.png" width="5.59in"}`images/b-apl-features/image1308.png`
 
 By taking the
 index vector from grade down of column 3 and telling item to apply it to
@@ -459,7 +459,7 @@ In case you’ve forgotten, ![image1309.png](images/b-apl-features/image1309.png
 database; we need the list 3 in the second input slot of the outer list
 to select by columns rather than by rows.
 
- ![image1311.png](images/b-apl-features/image1311.png) <!--  style="width:2.91667in;height:0.325in" -->
+ {img alt="image1311.png" width="2.95in"}`images/b-apl-features/image1311.png`
 
 Select ({index}`if take` ) or select all but (if drop
 ) the first (if *n*\>0) or last (if *n*\<0) |*n*|
@@ -467,7 +467,7 @@ items from a vector, or rows from a matrix. Alternatively, if the left
 input is a two-item vector, select rows with the first item and columns
 with the second.
 
- ![image1312.png](images/b-apl-features/image1312.png) <!--  style="width:2.91667in;height:0.325in" -->
+ {img alt="image1312.png" width="2.95in"}`images/b-apl-features/image1312.png`
 
 The {index}`compress block` selects a subset of its right
 input based on the Boolean values in its left input, which must be a
@@ -491,8 +491,8 @@ columns), while **⌿** is described as operating on rows. We were more
 than a month into this project before I understood all this. You get
 long block names so it won’t take you a month!
 
-![image1320.png](images/b-apl-features/image1320.png) <!--  style="width:2.99444in;height:0.23333in" / -->
-![image1319.png](images/b-apl-features/image1319.png) <!--  style="width:3.175in;height:0.18333in" / -->
+{img alt="image1320.png" width="2.99in"}`images/b-apl-features/image1320.png`
+{img alt="image1319.png" width="3.17in"}`images/b-apl-features/image1319.png`
 ![image1321.png](images/b-apl-features/image1321.png) <!--  style="width:1.11181in;height:0.23333in" --> Don’t confuse this
 block with the {index}`reduce block`, whose APL symbol is
 also a slash. In that block, what comes to the left of the slash is a
@@ -516,7 +516,7 @@ which row is where; the reverse column order block reverses which column
 is where; and the transpose block turns rows into columns and vice
 versa:
 
-![image1322.png](images/b-apl-features/image1322.png) <!--  style="width:1.11181in;height:0.23333in" -->
+{img alt="image1322.png" width="5.88in"}`images/b-apl-features/image1322.png`
 
 Except for reverse row order, these work only on full arrays, not
 ragged-right lists of lists, because the result of the other two would
@@ -548,7 +548,7 @@ applying the function to the array you want to compress.
 
 But APL does have a higher order version of combine:
 
-![image1323.png](images/b-apl-features/image1323.png) <!--  style="width:1.11181in;height:0.23333in" -->
+{img alt="image1323.png" width="5.88in"}`images/b-apl-features/image1323.png`
 
 The reduce block
 works just like combine, taking a dyadic function
@@ -561,21 +561,21 @@ matrix as made up of vectors, either row vectors or column vectors. And
 if you think of what these blocks do as adding vectors, rather than
 adding individual numbers, it’s clear that in
 
-![image1332.png](images/b-apl-features/image1332.png) <!--  style="width:6.68333in;height:1.04167in" -->
+{img alt="image1332.png" width="6.68in"}`images/b-apl-features/image1332.png`
 
-![image1333.png](images/b-apl-features/image1333.png) <!--  style="width:5.83333in;height:1.1in" -->
+{img alt="image1333.png" width="5.83in"}`images/b-apl-features/image1333.png`
 
  the *vector*
 (10, 26, 42) is the sum of *column vectors* (1, 5, 9)+(2, 6, 10)+(3, 7,
 11)+(4, 8, 12). In pre-6.0 Snap<em>!</em>, we’d get the same result this way:
 
-![image1334.png](images/b-apl-features/image1334.png) <!--  style="width:4.80833in;height:1.1in" -->
+{img alt="image1334.png" width="4.81in"}`images/b-apl-features/image1334.png`
 
 mapping over the *rows* of the matrix, applying combine to each row.
 Combining rows, reducing column vectors.
 
 
-![image1336.png](images/b-apl-features/image1336.png)
+{img alt="image1336.png" width="2.17in"}`images/b-apl-features/image1336.png`
 The outer product block takes two arrays
 (vectors, typically) and a dyadic scalar function as inputs. It reports
 an array whose rank is the sum of the ranks of the inputs (so, typically
@@ -586,7 +586,7 @@ of the left input and the third element of the right input. (The APL
 symbol ◦. is pronounced “jot dot.”) The way to think about this block is
 “multiplication table ” from elementary school:
 
-![image1335.png](images/b-apl-features/image1335.png) <!--  style="width:7.24in;height:1.52in" -->
+{img alt="image1335.png" width="7.24in"}`images/b-apl-features/image1335.png`
 
 ![image1337.png](images/b-apl-features/image1337.png) <!--  style="width:2.61667in;height:0.24167in" --> The inner product
 block takes two matrices and two operations
@@ -595,7 +595,7 @@ of rows in the right matrix. When the two operations are + and ×, this
 is the {index}`matrix multiplication<single: multiplication, matrix>` familiar to
 mathematicians:
 
-![image1338.png](images/b-apl-features/image1338.png) <!--  style="width:7.33861in;height:1.00694in" -->
+{img alt="image1338.png" width="7.34in"}`images/b-apl-features/image1338.png`
 
 But other operations can be used. One common inner product is ∨.∧ (“or
 dot and”) applied to Boolean matrices, to find rows and columns that
@@ -606,6 +606,6 @@ isn’t an APL function; it’s an aid to exploring
 APL-in-Snap<em>!</em>. It transforms arrays to a compact representation that
 still makes the structure clear:
 
-![image1340.png](images/b-apl-features/image1340.png) <!--  style="width:5.99792in;height:0.33333in" -->
+{img alt="image1340.png" width="6.00in"}`images/b-apl-features/image1340.png`
 
 Experts will recognize this as the Lisp representation of list structure.

--- a/docs/STYLEGUIDE.md
+++ b/docs/STYLEGUIDE.md
@@ -47,7 +47,7 @@ attribute in the same braces:
 
 ```md
 ![alt text](filename.png){width=2.84in}
-{inline alt="alt text" class="image-4x width=3in"}`filename.png`
+{inline alt="alt text" class="image-4x" width="3in"}`filename.png`
 ```
 
 MyST forwards `width=Xin` to `\includegraphics[width=Xin]{...}`, so the

--- a/docs/STYLEGUIDE.md
+++ b/docs/STYLEGUIDE.md
@@ -4,7 +4,7 @@
   unlike the rest of the manual. -->
 
 * Write UI elements inside quoted code blocks. e.g. ```"`Open`"```
-* Monospaced text should use the CSS class `.mono` e.g. `{span .mono}[text here]`
+* Monospaced text should use the CSS class `.mono` e.g. `{span .mono}`text here``
 * Do not put spaces around index entries. See [Indexes](#indexes) below.
 * To write Snap! as stylized text write: `Snap<em>!</em>`
 * Chapters are included at the top level of the repo, named 'NN-chapter.md'

--- a/index.md
+++ b/index.md
@@ -1,6 +1,7 @@
 ---
 ---
 
+# Snap! Reference Manual
 <!--
   Title intentionally omitted. The PDF cover page already carries
   "Snap! Reference Manual"; emitting a frontmatter title here (or

--- a/index.md
+++ b/index.md
@@ -58,7 +58,7 @@ A search function is included in the upper right hand corner. If you which you c
 
 ### Reference the Snap! Manual
 
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.16892852.svg)](https://doi.org/10.5281/zenodo.16892852)
+[DOI: 10.5281/zenodo.16892852](https://doi.org/10.5281/zenodo.16892852)
 
 If you're writing a paper or book and want to reference the manual, please use the following citation:
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "styles:build": "sass _support/styles/snap-manual.scss _support/styles/snap-manual.css --style=compressed --no-source-map",
     "styles:watch": "sass --watch _support/styles/snap-manual.scss:_support/styles/snap-manual.css",
-    "dev": "npm run styles:build && jupyter-book start",
+    "dev": "npm run styles:build && jupyter-book start --max-size-webp 0.01",
     "build": "npm run styles:build && jupyter-book build --html",
     "pdf": "jupyter-book build --pdf && open output/snap-manual.pdf"
   }


### PR DESCRIPTION
## Fix LaTeX PDF conversion errors and improve image sizing

Resolves several LaTeX compilation errors from the docx → PDF pipeline that caused missing content, index corruption, and broken layouts. Also introduces a script to restore original image dimensions from the source Word document, updating 324 images across 13 chapters.

## Changes

**LaTeX error fixes:**
- Fix broken image path (`01-blocks-scripts-And-sprites/image138` → lowercase) that caused a missing block icon in the Etcetera section
- Replace Quarto-style `:::{.evenly-spaced-images}` divs in `06-procedures-as-data.md` with MyST-compatible `:::{grid}` blocks (a `<br/>` inside the old div was generating invalid LaTeX)
- Fix index corruption caused by `≤` in index entries — makeindex was emitting an unclosed `\textbf{` that aborted the index `multicols` early; add `asciiSortKey()` to map non-ASCII symbols to ASCII names in the sort field
- Replace Zenodo SVG badge in `index.md` with a plain DOI link (the SVG served as `text/plain` was producing unrenderable `mystRoleError` nodes)
- Fix two broken cross-references (`@sec-nesting-sprites-anchors-and-parts` → `@nesting-sprites-anchors-and-parts`; restructure `{#fig-rainbow}` into a proper MyST target)

**Symbol substitution:**
- Extend `latex-shims.mjs` body-font symbol map to cover `➔` (used in block names like `sentence ➔ list`) → `\textrightarrow{}`, preventing missing-glyph boxes in body text and the index

**Image sizing:**
- Add `_support/scripts/apply-docx-widths.py` — re-extracts the docx via pandoc, builds an `imageNN → width-in-inches` map, and rewrites plain `![alt](path)` block images as `{img alt="..." width="Xin"}` roles
- 324 images updated across 13 chapter/appendix files; editor screenshots (~5 in. in docx) now render at their original size instead of the 30% linewidth fallback

## Visual Changes

**Before/after page 5 (annotated IDE screenshot):**
- [Before](https://www.superconductor.com/ticket_implementations/6wGzgTQWcwLd/artifacts/8HR98K8gmtpQ) — screenshot shrunk to ~2.25 in.
- [After](https://www.superconductor.com/ticket_implementations/6wGzgTQWcwLd/artifacts/nGrnk8KTCnj7) — screenshot at full usable width

**Index pages (≤ block entry and arrow symbols):**
- [Index p.188](https://www.superconductor.com/ticket_implementations/6wGzgTQWcwLd/artifacts/WQwDh6HrL98m) / [p.189](https://www.superconductor.com/ticket_implementations/6wGzgTQWcwLd/artifacts/QWQBdrnDjhn9) — `➔` now renders correctly; `≤` group no longer breaks the index

**Chapter 6 Special Forms layout:**
- [Before](https://www.superconductor.com/ticket_implementations/6wGzgTQWcwLd/artifacts/jMRfNkQRgnjG) — Quarto div leaked into LaTeX
- [After](https://www.superconductor.com/ticket_implementations/6wGzgTQWcwLd/artifacts/9wb77nzbdwTP) — proper 2+1 grid layout

---

[Superconductor Ticket Implementation](https://www.superconductor.com/tickets/h9nwJPCqfm7m/implementations/6wGzgTQWcwLd) | [Guided Review](https://www.superconductor.com/tickets/h9nwJPCqfm7m/implementations/6wGzgTQWcwLd?tab=guided_review)

<!-- created-by-superconductor -->