### PR TITLE
Add native 'must' buttons for PDF and blocks reference downloads, enabling alternate PDF file in 'myst'

### DIFF
--- a/myst.yml
+++ b/myst.yml
@@ -22,6 +22,11 @@ project:
     - '**/*.tex'
   downloads:
     - id: output-pdf-primary
+      title: Download PDF
+    - id: output-pdf-with-blocks
+      title: Download PDF with Blocks Reference
+    - id: output-pdf-blocks-ref
+      title: Download Blocks Reference
   plugins:
     - https://github.com/choldgraf/myst-substitutions/releases/download/v0.1/index.mjs
     - _support/plugins/inline-image.mjs
@@ -43,7 +48,7 @@ project:
 extends:
   - toc.yml
   - toc_pdf.yml
-  # - toc_pdf_alternates.yml
+  - toc_pdf_alternates.yml
 
 site:
   template: book-theme

--- a/toc_pdf_alternates.yml
+++ b/toc_pdf_alternates.yml
@@ -1,7 +1,8 @@
 version: 1
 project:
   exports:
-  - format: tex+pdf
+  - id: output-pdf-with-blocks
+    format: tex+pdf
     title: Snap\textit{!} Reference Manual \& Blocks Reference
     template: ./_latex-template/
     output: output/snap-manual-blocks-ref.pdf
@@ -467,7 +468,8 @@ project:
       - file: blocks/lists/reportCrossproduct.md
         level: 3
       # \printindex emits the index from the LaTeX template directly.
-  - format: tex+pdf
+  - id: output-pdf-blocks-ref
+    format: tex+pdf
     title: Snap\textit{!} Blocks Reference
     template: ./_latex-template/
     output: output/snap-blocks-ref.pdf


### PR DESCRIPTION
## Add native download buttons for PDF and blocks reference variants

Enables the alternate PDF exports in MyST and surfaces all three document variants as native download buttons in the site navigation.

## Changes

- **`toc_pdf_alternates.yml`**: Added `id: output-pdf-with-blocks` and `id: output-pdf-blocks-ref` to the two alternate exports so they can be referenced as named downloads
- **`myst.yml`**: Uncommented `toc_pdf_alternates.yml` in `extends` so MyST actually builds the alternate PDFs
- **`myst.yml`**: Added all three download entries with display titles to the `downloads:` config:
  - "Download PDF" (primary)
  - "Download PDF with Blocks Reference"
  - "Download Blocks Reference"

---

[Superconductor Ticket Implementation](https://www.superconductor.com/tickets/tP8RhW8QdTq7/implementations/wh9LkdRRgKjg) | [Guided Review](https://www.superconductor.com/tickets/tP8RhW8QdTq7/implementations/wh9LkdRRgKjg?tab=guided_review)

<!-- created-by-superconductor -->