### PR TITLE
Fix line breaks appearing after inline images in compiled PDF

### DIFF
--- a/_latex-template/template.tex
+++ b/_latex-template/template.tex
@@ -211,6 +211,25 @@
 }
 \makeatother
 
+% Inline-image \par swallow. myst-to-tex's image handler always emits
+% "\n\n" after \includegraphics (its closeBlock), which LaTeX reads as
+% \par and breaks the surrounding paragraph after an inline image. The
+% latex-shims plugin inserts \snapinlineparhook just before every inline
+% image that has more content following it in the same parent. The hook
+% installs a one-shot redefinition of \par that fires for the very next
+% \par, undoes the trailing space the end-of-line inserted, restores the
+% real \par, and lets the paragraph continue.
+\makeatletter
+\newcommand{\snapinlineparhook}{%
+  \let\snap@par@orig\par%
+  \let\par\snap@par@swallow%
+}
+\def\snap@par@swallow{%
+  \let\par\snap@par@orig%
+  \unskip%
+}
+\makeatother
+
 % --- <kbd> rendering ----------------------------------------------------
 % Used by the latex-shims plugin to render the MyST `keyboard` node.
 \newcommand{\kbd}[1]{%

--- a/_support/plugins/latex-shims.mjs
+++ b/_support/plugins/latex-shims.mjs
@@ -380,8 +380,44 @@ const latexShimsTransform = {
         imageNode.width = normalizeWidth(imageNode.width);
       }
     });
+
+    // 6. Inline-image paragraph-break suppression.
+    //    myst-to-tex's image handler unconditionally emits "\n\n" after each
+    //    \includegraphics, which LaTeX reads as \par and ends the surrounding
+    //    paragraph. For inline images that have following content in the same
+    //    parent (text, more inline images, etc.) that produces an unwanted
+    //    line break right after the image. We can't override the handler from
+    //    a plugin, so instead we insert a raw \snapinlineparhook node before
+    //    each such image; the macro (defined in template.tex) installs a
+    //    one-shot \par redefinition that swallows the next \par (and the
+    //    space the end-of-line generates immediately before it). Inline
+    //    images that are the last child of their parent are left alone so
+    //    legitimate paragraph breaks still happen.
+    walkWithParent(tree, null, (node, parent) => {
+      if (node.type !== 'image') return;
+      if (inlineSentinel(node) == null) return;
+      if (!parent || !Array.isArray(parent.children)) return;
+      const idx = parent.children.indexOf(node);
+      if (idx < 0 || idx === parent.children.length - 1) return;
+      parent.children.splice(idx, 0, {
+        type: 'raw',
+        lang: 'tex',
+        tex: '\\snapinlineparhook ',
+      });
+    });
   },
 };
+
+// Walk the tree calling fn(node, parent) on each node. The walk records
+// children before recursing so mutations to parent.children inside fn (e.g.,
+// splicing a sibling before `node`) don't double-visit or skip nodes.
+function walkWithParent(node, parent, fn) {
+  if (!node) return;
+  fn(node, parent);
+  const children = Array.isArray(node.children) ? node.children.slice() : null;
+  if (!children) return;
+  for (const child of children) walkWithParent(child, node, fn);
+}
 
 export default {
   name: 'LaTeX shims (kbd, grid, image, index, lightning)',


### PR DESCRIPTION
## Fix unwanted line breaks after inline images in compiled PDF

Inline images in the compiled PDF were causing paragraph breaks, resulting in unwanted line breaks mid-sentence. This fix suppresses those breaks for inline images that have following content in the same paragraph.

## Changes

- **`_latex-template/template.tex`**: Added a `\snapinlineparhook` macro that installs a one-shot redefinition of `\par`, swallowing the next paragraph break (and trailing space) so the surrounding paragraph continues uninterrupted.
- **`_support/plugins/latex-shims.mjs`**: Added a new AST transform step that inserts `\snapinlineparhook` before each inline image that has content following it in the same parent. Inline images at the end of their parent are left untouched so legitimate paragraph breaks are preserved. Also added a `walkWithParent` helper to safely traverse and mutate the AST.

## Root Cause

`myst-to-tex`'s image handler unconditionally emits `\n\n` after every `\includegraphics`, which LaTeX interprets as `\par`, breaking the paragraph after every inline image. Since the handler can't be overridden from a plugin, the fix intercepts at the AST level before rendering.

## Visual Changes

[Page 63 — inline image now flows correctly within the paragraph](https://www.superconductor.com/ticket_implementations/Qwth9M7KKjtT/artifacts/WF8KzbRRFth9)

---

[Superconductor Ticket Implementation](https://www.superconductor.com/tickets/RzPM8LKDhR9Q/implementations/Qwth9M7KKjtT) | [Guided Review](https://www.superconductor.com/tickets/RzPM8LKDhR9Q/implementations/Qwth9M7KKjtT?tab=guided_review)

<!-- created-by-superconductor -->