### PR TITLE
Update manual to reflect latest jb2 builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       },
       "devDependencies": {
         "js-yaml": "^4.1.1",
-        "jupyter-book": "^2.1.5",
-        "mystmd": "^1.8.3",
+        "jupyter-book": "^2.1.6",
+        "mystmd": "^1.10.1",
         "sass": "^1.99.0"
       }
     },
@@ -404,9 +404,9 @@
       }
     },
     "node_modules/jupyter-book": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/jupyter-book/-/jupyter-book-2.1.5.tgz",
-      "integrity": "sha512-CnBJvxxaZ1iB1Ei9gqDQFpEQdsp3EnrS9SugkisUFLwPLqY4sv0KqroFXULS4iNdR/IMsmz8gaRevAiKjyybYA==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/jupyter-book/-/jupyter-book-2.1.6.tgz",
+      "integrity": "sha512-wbZLvYxGWcxBpyk+4rZm2cXA+UIDW5Oh56Y0rcrMuQmbQNhTIa72aBzRsU3sRrb63bAKsH9RO9ZpWIeheqRBiw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "bin": {
@@ -424,9 +424,9 @@
       "license": "MIT"
     },
     "node_modules/mystmd": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/mystmd/-/mystmd-1.8.3.tgz",
-      "integrity": "sha512-sAdTEgy3EX9lc/qddzgJU62oCZTMhGgu0GZsCuMCmOuXXsyDMqHGW4lEE+eMmk8bx+2DsmkTnlQnaKgVq03gfw==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/mystmd/-/mystmd-1.10.1.tgz",
+      "integrity": "sha512-nczabm7R8PmoqJVqKpaijTr1kxdwnY+hRoFC7b+NEUdxW5yZZ8n/CuJlMJKlHtG/pA4o3Ia2RP/0Ra3UPj6sFg==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "devDependencies": {
     "js-yaml": "^4.1.1",
-    "jupyter-book": "^2.1.5",
-    "mystmd": "^1.8.3",
+    "jupyter-book": "^2.1.6",
+    "mystmd": "^1.10.1",
     "sass": "^1.99.0"
   },
   "scripts": {


### PR DESCRIPTION
## Update JB2 toolchain to latest versions

Bumps the Jupyter Book 2 toolchain dependencies to their latest releases to keep the manual build current.

## Changes

- Update `jupyter-book` from `2.1.5` → `2.1.6`
- Update `mystmd` from `1.8.3` → `1.10.1`
- Refresh `package-lock.json` to reflect updated dependency tree

## Notes

No manual content or configuration files were modified — this is a pure toolchain update. A full HTML build was validated successfully across all 220 pages. Pre-existing warnings about absent local PDF downloads, ignored config keys (`substitutions`/`parser`), and inch-based image widths remain but are unrelated to this change.

---

[Superconductor Ticket Implementation](https://www.superconductor.com/tickets/BK6T9NJMRBQM/implementations/WbzjfQTtmggd) | [Guided Review](https://www.superconductor.com/tickets/BK6T9NJMRBQM/implementations/WbzjfQTtmggd?tab=guided_review)

<!-- created-by-superconductor -->